### PR TITLE
Feature/activate https for LuCI-Admin-interface

### DIFF
--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -1007,6 +1007,13 @@ r1_2_1_olsrd_watchdog_crontab() {
   /etc/init.d/cron restart
 }
 
+r1_2_2_https_interface() {
+  log "enabling redirection to TLS-encrypted LuCI-Interface"
+  uci set uhttpd.main.redirect_https=1
+  uci commit uhttpd
+  service uhttpd reload
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -1119,6 +1126,10 @@ migrate () {
     r1_2_1_rpcd
     r1_2_1_ffwizard
     r1_2_1_olsrd_watchdog_crontab
+  fi
+
+  if semverLT ${OLD_VERSION} "1.2.2"; then
+    r1_2_2_https_interface
   fi
 
   # overwrite version with the new version

--- a/packages/falter-berlin-uhttpd-defaults/uci-defaults/freifunk-berlin-uhttpd-defaults
+++ b/packages/falter-berlin-uhttpd-defaults/uci-defaults/freifunk-berlin-uhttpd-defaults
@@ -7,6 +7,8 @@ guard "uhttpd"
 # this should help us to avoid different certificates with same
 # commonname/issuer id
 uci set uhttpd.px5g.commonname="Freifunk Berlin - $(dd if=/dev/urandom bs=4 count=1 | hexdump -e '1/1 "%02x"')"
-# do not force redirect to https
-uci set uhttpd.main.redirect_https=0
+# do force redirect to https for encrypted web interface
+uci set uhttpd.main.redirect_https=1
 uci commit
+
+service uhttpd reload


### PR DESCRIPTION
Enables https-redirection for LuCI-Admin-Interface and handles mifration too.

Please cherry-pick into just 21.02

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
