### PR TITLE
luci-app-falter-owm: Fix uptime in owm.sh

### DIFF
--- a/luci/luci-app-falter-owm/files/owm.sh
+++ b/luci/luci-app-falter-owm/files/owm.sh
@@ -214,7 +214,7 @@ json_add_object system
 		json_add_string "" "system is deprecated"
 		json_add_string "" "$model"
 	json_close_array
-	json_add_array
+	json_add_array uptime
 		json_add_int "" $uptime
 	json_close_array
 	json_add_array loadavg


### PR DESCRIPTION
There was some little word missing in owm.sh. In result, the
uptime was not included right into the json-string. On the map
nodes with the old version of the script show constantly an up-
time of just a few seconds.

Signed-off-by: Martin Hübner <martin.hubner@web.de>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
