### PR TITLE
falter-berlin-migration: migration for 1.2.1

### DIFF
--- a/packages/falter-berlin-migration/Makefile
+++ b/packages/falter-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-berlin-migration
-PKG_VERSION:=8
+PKG_VERSION:=9
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 


### PR DESCRIPTION
Ensure that /etc/profile.d/dynbanner.sh is removed
Ensure that the ubus.sock is defined correctly in rpcd
Remove unneeded mode_radioN options in ffwizard
Remove ff_olsr_watchdog script from crontab

Fixes: #264
Signed-off-by: pmelange <isprotejesvalkata@gmail.com>
