### PR TITLE
luci-app-falter-owm: exclude wireguard interfaces

### DIFF
--- a/luci/luci-app-falter-owm/Makefile
+++ b/luci/luci-app-falter-owm/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-falter-owm
-PKG_VERSION:=2022.01.09
+PKG_VERSION:=2022.01.30
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 PKG_BUILD_DEPENDS += lua/host luci-base/host LUCI_CSSTIDY:csstidy/host LUCI_SRCDIET:luasrcdiet/host $(LUCI_BUILD_DEPENDS)
@@ -19,7 +19,7 @@ define Package/luci-app-falter-owm/default
   SECTION:=luci
   CATEGORY:=LuCI
   SUBMENU:=3. Applications
-  URL:=https://github.com/Freifunk-Spalter/packages
+  URL:=https://github.com/freifunk-berlin/falter-packages
   PKGARCH:=all
 endef
 

--- a/luci/luci-app-falter-owm/files/owm.sh
+++ b/luci/luci-app-falter-owm/files/owm.sh
@@ -61,7 +61,9 @@ olsr4_links() {
 	json_get_var olsrInterface olsrInterface
 	json_get_var ifName ifName
 	json_select ..
-	olsr4links="$olsr4links$localIP $remoteIP $remotehost $linkQuality $ifName;"
+	if [[ "$olsrInterface" != *"wg_"* ]]; then
+		olsr4links="$olsr4links$localIP $remoteIP $remotehost $linkQuality $ifName;"
+	fi
 }
 
 olsr6_links() {

--- a/luci/luci-app-falter-owm/files/owm.sh
+++ b/luci/luci-app-falter-owm/files/owm.sh
@@ -61,7 +61,7 @@ olsr4_links() {
 	json_get_var olsrInterface olsrInterface
 	json_get_var ifName ifName
 	json_select ..
-	if [[ "$olsrInterface" != *"wg_"* ]]; then
+	if ! echo "$olsrInterface" | grep -q '.*wg_.*'; then
 		olsr4links="$olsr4links$localIP $remoteIP $remotehost $linkQuality $ifName;"
 	fi
 }
@@ -75,7 +75,9 @@ olsr6_links() {
 	json_get_var olsrInterface olsrInterface
 	json_get_var ifName ifName
 	json_select ..
-	olsr6links="$olsr6links$localIP $remoteIP $remotehost $linkQuality $ifName;"
+	if ! echo "$olsrInterface" | grep -q '.*wg_.*'; then
+		olsr6links="$olsr6links$localIP $remoteIP $remotehost $linkQuality $ifName;"
+	fi
 }
 
 # This section is relevant for hopglass statistics feature (isUplink/isHotspot)


### PR DESCRIPTION
Do not add interfaces with "wg_" in the name.
