### PR TITLE
Add service registrar

### DIFF
--- a/luci/luci-app-falter-service-registrar/Makefile
+++ b/luci/luci-app-falter-service-registrar/Makefile
@@ -1,0 +1,10 @@
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI support for Freifunk Berlin Service-Registrar
+LUCI_EXTRA_DEPENDS:=falter-berlin-service-registrar
+LUCI_PKGARCH:=all
+
+include ../include-luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js
+++ b/luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js
@@ -1,0 +1,91 @@
+'use strict';
+'require view';
+'require form';
+'require validation';
+
+return view.extend({
+    render: function () {
+
+        function olsr_description_validator(section_id, value) {
+            return (String(value).match(/^[a-zA-Z0-9 \-]+$/) && String(value).length <= 75 ? true : _('Require string with characters, numbers and whitespace only. It must be less than 75 characters long.'))
+        };
+
+        var m, s, o, t, opt;
+
+        m = new form.Map('ffservices', _('Set up Freifunk services'), _(`<br>
+        <p>This site gives you the chance to define your own services for the Freifunk network. If you enter the service
+        details here, they will get announced to the mesh and other Freifunkers can use them. It's quite similar
+        to regular web services, except this ones only live in Freifunk network. But there are other ways to get
+        your service exposed to the internet. Just ask us, if you are interested in that.</p>
+
+        <p>You can find two tabs in this app: <b>Websites</b> and <b>Generic Services</b>.
+        They differ in what you want to do and how much you are experienced.</p>
+
+        <p><b>Websites</b> will configure you a (static) website on your router. It will not only announce it to the mesh, but
+        will additionally set up OpenWrts <i>uhttpd</i>-webserver, to serve your site. Please mind: As by the limitations
+        of <i>uhttpd</i>, every Website must have it's own port. Especially you cannot use port 80, unless you deactivate
+        the LuCI web-ui, which uses that port per default.</p>
+
+        <p>The <b>Generic Services</b> gives you more flexibility in that way, that you can configure services that run on
+        some other host in your local Freifunk net. If you are going to expose a webcam or some kind of server, this
+        option is the right one for you.</p><br>`));
+        m.tabbed = true;
+
+        s = m.section(form.TypedSection, 'website', _('Websites'));
+        s.addremove = true;
+        s.anonymous = true;
+
+        t = m.section(form.TypedSection, 'service', _('Generic Services'));
+        t.addremove = true;
+        t.anonymous = true;
+
+        var o0, o1, o2, o3, o4, o5;
+        o0 = s.option(form.Value, 'fqdn', _('FQDN'), _('The Fully-Qualified-Domain-Name of your website, i.e.: "example.olsr". This is URL on which your service will be available in the Freifunk network.'));
+        o0.rmempty = false;
+        o0.datatype = 'hostname';
+        o1 = s.option(form.Value, 'description', _('Description'), _('Give a short description or title'));
+        o1.rmempty = false;
+        o1.validate = olsr_description_validator;
+
+        o2 = s.option(form.ListValue, 'protocol', _('Protocol'));
+        o2.value('tcp', 'TCP');
+        o2.rmempty = false;
+        o2.editable = false;
+
+        o3 = s.option(form.Value, 'port', _('Port'));
+        o3.datatype = 'and(port, min(81))';
+        o3.rmempty = false;
+        o4 = s.option(form.Value, 'web_root', _('Web Root'), _('Give the directory where your site lives.'));
+        o4.rmempty = false;
+        o4.datatype = 'and(directory, maxlength(253))';
+        o5 = s.option(form.Flag, 'disabled', _('Disabled'), _("Don't publish this site"));
+        o5.default = '0';
+        o5.rmempty = false;
+
+        var opt0, opt1, opt2, opt3, opt4, opt5;
+        opt0 = t.option(form.Value, 'fqdn', _('FQDN'), _('The FQDN of your website, i.e.: "example.olsr"'));
+        opt0.rmempty = false;
+        opt0.datatype = 'hostname';
+        opt1 = t.option(form.Value, 'description', _('Description'), _('Give a short description or title'));
+        opt1.rmempty = false;
+        opt1.validate = olsr_description_validator;
+
+        opt2 = t.option(form.ListValue, 'protocol', _('Protocol'));
+        opt2.value('tcp', 'TCP');
+        opt2.value('udp', 'UDP');
+        opt2.rmempty = false;
+        opt2.editable = true;
+
+        opt3 = t.option(form.Value, 'port', _('Port'));
+        opt3.datatype = 'and(port, min(80))';
+        opt3.rmempty = false;
+        opt4 = t.option(form.Value, 'ip_addr', _('IP-Address'), _('Must be a valid address from the routers host network.'));
+        opt4.datatype = 'ipaddr';
+        opt4.rmempty = false;
+        opt5 = t.option(form.Flag, 'disabled', _('Disabled'), _("Don't publish this service"));
+        opt5.default = '0';
+        opt5.rmempty = false;
+
+        return m.render();
+    },
+});

--- a/luci/luci-app-falter-service-registrar/po/de/service-registrar.po
+++ b/luci/luci-app-falter-service-registrar/po/de/service-registrar.po
@@ -1,0 +1,202 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Martin Hübner <martin.hubner@web.de>\n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.2.2\n"
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:15
+msgid ""
+"<br> <p>This site gives you the chance to define your own services for the "
+"Freifunk network. If you enter the service details here, they will get "
+"announced to the mesh and other Freifunkers can use them. It's quite similar "
+"to regular web services, except this ones only live in Freifunk network. But "
+"there are other ways to get your service exposed to the internet. Just ask "
+"us, if you are interested in that.</p> <p>You can find two tabs in this app: "
+"<b>Websites</b> and <b>Generic Services</b>. They differ in what you want to "
+"do and how much you are experienced.</p> <p><b>Websites</b> will configure "
+"you a (static) website on your router. It will not only announce it to the "
+"mesh, but will additionally set up OpenWrts <i>uhttpd</i>-webserver, to "
+"serve your site. Please mind: As by the limitations of <i>uhttpd</i>, every "
+"Website must have it's own port. Especially you cannot use port 80, unless "
+"you deactivate the LuCI web-ui, which uses that port per default.</p> <p>The "
+"<b>Generic Services</b> gives you more flexibility in that way, that you can "
+"configure services that run on some other host in your local Freifunk net. "
+"If you are going to expose a webcam or some kind of server, this option is "
+"the right one for you.</p><br>"
+msgstr ""
+"<br> <p>Auf dieser Seite kannst du deine eigenen Dienste für das "
+"Freifunknetz definieren. Wenn du hier die Daten deines Dienstes eingibst, "
+"werden sie im Mesh verteilt und andere Freifunker können deinen Dienst "
+"nutzen. Es ist so ähnlich wie das Internet, außer das diese Dienste nur "
+"innerhalb des Freifunknetzes erreichbar sind. Aber es gibt andere "
+"Möglichkeiten, deinen Dienst auch ins Internet zu bringen. Sprich uns "
+"einfach an, wenn du darauf Lust hast.</p> <p>In dieser App gibt es zwei "
+"Tabs: <b>Webseiten</b> und <b>Allgemeine Dienste</b>. Welchen du wählen "
+"solltest hängt davon ab, was du erreichen möchtest und wie viel Vorerfahrung "
+"du mitbringst.</p> <p><b>Webseiten</b> wird eine (statische) Webseite auf "
+"deinem Router konfigurieren. Es wird nicht nur das Registrieren erledigt, "
+"sondern zusätzlich wird OpenWrts <i>uhttpd</i>-Webserver so konfiguriert, "
+"dass er deine Seite auch ausliefert. Bitte beachte: Wegen ein paar "
+"Einschränkungen mit <i>uhttpd</i>, muss jede Webseite ihren eigenen Port "
+"haben. Insbesondere kann man nicht Port 80 nutzen, außer du deaktivierst das "
+"LuCI-Webinterface, das standardmäßig dort läuft.</p> <p>Der Tab "
+"<b>Allgemeine Dienste</b> hat eine größere Flexibilität: Man kann hier "
+"Dienste definieren, die auf einem anderen Gerät in deinem lokalen "
+"Freifunknetz laufen. Wenn du z.B. eine Webcam teilen möchtest, oder eine Art "
+"Server betreibst, ist diese Option genau richtig für dich.</p><br>"
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:46
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:69
+msgid "Description"
+msgstr "Beschreibung"
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:61
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:85
+msgid "Disabled"
+msgstr "Deaktiviert"
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:85
+msgid "Don't publish this service"
+msgstr "Dienst nicht veröffentlichen"
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:61
+msgid "Don't publish this site"
+msgstr "Seite nicht veröffentlichen"
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:43
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:66
+msgid "FQDN"
+msgstr "FQDN"
+
+#: luci/luci-app-falter-service-registrar/root/usr/share/luci/menu.d/luci-app-falter-service-registrar.json:3
+msgid "Freifunk"
+msgstr "Freifunk"
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:38
+msgid "Generic Services"
+msgstr "Allgemeine Dienste"
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:46
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:69
+msgid "Give a short description or title"
+msgstr "Kurze Beschreibung oder Titel angeben"
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:58
+msgid "Give the directory where your site lives."
+msgstr "Verzeichnis, in dem die Seite liegt, angeben."
+
+#: luci/luci-app-falter-service-registrar/root/usr/share/rpcd/acl.d/luci-app-falter-service-registrar.json:3
+msgid "Grant UCI access to LuCI app falter-service-registrar"
+msgstr "UCI-Zugriff für LuCI app falter-service-registrar gewähren"
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:82
+msgid "IP-Address"
+msgstr "IP-Adresse"
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:82
+msgid "Must be a valid address from the routers host network."
+msgstr "Muss eine gültige Adresse aus dem Host-Netzwerk des Routers sein."
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:55
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:79
+msgid "Port"
+msgstr "Port"
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:50
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:73
+msgid "Protocol"
+msgstr "Protokoll"
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:10
+msgid ""
+"Require string with characters, numbers and whitespace only. It must be less "
+"than 75 characters long."
+msgstr ""
+"Text darf nur Buchstaben, Zahlen und Leerzeichen enthalten. Er muss weniger "
+"als 75 Zeichen lang sein."
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:15
+#: luci/luci-app-falter-service-registrar/root/usr/share/luci/menu.d/luci-app-falter-service-registrar.json:14
+msgid "Set up Freifunk services"
+msgstr "Freifunkdienste aufsetzen"
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:66
+msgid "The FQDN of your website, i.e.: \"example.olsr\""
+msgstr "Der FQDN deiner Webseite, z.B. \"example.olsr\"."
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:43
+msgid ""
+"The Fully-Qualified-Domain-Name of your website, i.e.: \"example.olsr\". "
+"This is URL on which your service will be available in the Freifunk network."
+msgstr ""
+"Der FQDN deiner Webseite, z.B. \"example.olsr\". Das ist die URL unter "
+"welcher dein Service im Freifunknetz erreichbar sein wird."
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:58
+msgid "Web Root"
+msgstr "Webroot"
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:34
+msgid "Websites"
+msgstr "Webseiten"
+
+#~ msgid "Set Up Freifunk Services"
+#~ msgstr "Freifunkdienste aufsetzen"
+
+#~ msgid ""
+#~ "<br> <p>This site gives you the chance to define your own services for "
+#~ "the Freifunk Network. If you enter the service details here, they will "
+#~ "get announced to the mesh and other Freifunkers can use them. It's quite "
+#~ "similar to regular web services, except this ones only live in Freifunk "
+#~ "Network. But there are other ways to get your service exposed to the "
+#~ "internet. Just ask us, if you are interested in that.</p> <p>You can find "
+#~ "two tabs in this app: <b>Websites</b> and <b>Generic Services</b>. They "
+#~ "differ in what you want to do and how much you are experienced.</p> "
+#~ "<p><b>Websites</b> will configure you a (static) website on your router. "
+#~ "It will not only announce it to the mesh, but will aditionally set up "
+#~ "OpenWrts <i>uhttpd</i>-webserver, to serve your site. Please mind: As by "
+#~ "the limitations of <i>uhttpd</i>, every Website must have it's own port. "
+#~ "Especially you cannot use port 80, unless you deactivate the luci web-ui, "
+#~ "which uses that port per default.</p> <p>The <b>Generic Services</b> "
+#~ "gives you more flexibility in that way, that you can configure services "
+#~ "that run on some other host in your local Freifunk Net. If you are going "
+#~ "to expose a webcam or some kind of server, this option is the right one "
+#~ "for you.</p><br>"
+#~ msgstr ""
+#~ "<br> <p>Auf dieser Seite kannst du deine eigenen Dienste für das "
+#~ "Freifunknetz definieren. Wenn du hier die Daten deines Dienstes eingibst, "
+#~ "werden sie im Mesh verteilt und andere Freifunker können deinen Dienst "
+#~ "nutzen. Es ist so ähnlich wie das Internet, außer das diese Dienste nur "
+#~ "innerhalb des Freifunknetzes erreichbar sind. Aber es gibt andere "
+#~ "Möglichkeiten, deinen Dienst auch ins Internet zu bringen. Sprich uns "
+#~ "einfach an, wenn du darauf Lust hast.</p> <p>In dieser App gibt es zwei "
+#~ "Tabs: <b>Webseiten</b> und <b>Allgemeine Dienste</b>. Welchen du wählen "
+#~ "solltest hängt davon ab, was du erreichen möchtest und wie viel "
+#~ "Vorerfahrung du mitbringst.</p> <p><b>Webseiten</b> wird eine (statische) "
+#~ "Webseite auf deinem Router konfigurieren. Es wird nicht nur das "
+#~ "Registrieren erledigt, sondern zusätzlich wird OpenWrts <i>uhttpd</i>-"
+#~ "Webserver so konfiguriert, dass er deine Seite auch ausliefert. Bitte "
+#~ "beachte: Wegen ein paar Einschränkungen mit <i>uhttpd</i>, muss jede "
+#~ "Webseite ihren eigenen Port haben. Insbesondere kann man nicht Port 80 "
+#~ "nutzen, außer du deaktivierst das LuCI-Webinterface, das standardmäßig "
+#~ "dort läuft.</p> <p>Der Tab <b>Allgemeine Dienste</b> hat eine größere "
+#~ "Flexibilität: Man kann hier Dienste definieren, die auf einem anderen "
+#~ "Gerät in deinem lokalen Freifunknetz laufen. Wenn du z.B. eine Webcam "
+#~ "teilen möchtest, oder eine Art Server betreibst, ist diese Option genau "
+#~ "richtig für dich.</p><br>"
+
+#~ msgid "Set up Freifunk Services"
+#~ msgstr "Freifunkdienste aufsetzen"
+
+#~ msgid "The FQDN of your Website, i.e.: \"example.olsr\""
+#~ msgstr "Der FQDN deiner Webseite, z.B. \"example.olsr\""
+
+#~ msgid "Register Freifunk Services"
+#~ msgstr "Freifunk-Dienste registrieren"

--- a/luci/luci-app-falter-service-registrar/po/templates/service-registrar.pot
+++ b/luci/luci-app-falter-service-registrar/po/templates/service-registrar.pot
@@ -1,0 +1,114 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:15
+msgid ""
+"<br> <p>This site gives you the chance to define your own services for the "
+"Freifunk network. If you enter the service details here, they will get "
+"announced to the mesh and other Freifunkers can use them. It's quite similar "
+"to regular web services, except this ones only live in Freifunk network. But "
+"there are other ways to get your service exposed to the internet. Just ask "
+"us, if you are interested in that.</p> <p>You can find two tabs in this app: "
+"<b>Websites</b> and <b>Generic Services</b>. They differ in what you want to "
+"do and how much you are experienced.</p> <p><b>Websites</b> will configure "
+"you a (static) website on your router. It will not only announce it to the "
+"mesh, but will additionally set up OpenWrts <i>uhttpd</i>-webserver, to "
+"serve your site. Please mind: As by the limitations of <i>uhttpd</i>, every "
+"Website must have it's own port. Especially you cannot use port 80, unless "
+"you deactivate the LuCI web-ui, which uses that port per default.</p> <p>The "
+"<b>Generic Services</b> gives you more flexibility in that way, that you can "
+"configure services that run on some other host in your local Freifunk net. "
+"If you are going to expose a webcam or some kind of server, this option is "
+"the right one for you.</p><br>"
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:46
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:69
+msgid "Description"
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:61
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:85
+msgid "Disabled"
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:85
+msgid "Don't publish this service"
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:61
+msgid "Don't publish this site"
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:43
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:66
+msgid "FQDN"
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/root/usr/share/luci/menu.d/luci-app-falter-service-registrar.json:3
+msgid "Freifunk"
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:38
+msgid "Generic Services"
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:46
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:69
+msgid "Give a short description or title"
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:58
+msgid "Give the directory where your site lives."
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/root/usr/share/rpcd/acl.d/luci-app-falter-service-registrar.json:3
+msgid "Grant UCI access to LuCI app falter-service-registrar"
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:82
+msgid "IP-Address"
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:82
+msgid "Must be a valid address from the routers host network."
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:55
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:79
+msgid "Port"
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:50
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:73
+msgid "Protocol"
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:10
+msgid ""
+"Require string with characters, numbers and whitespace only. It must be less "
+"than 75 characters long."
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:15
+#: luci/luci-app-falter-service-registrar/root/usr/share/luci/menu.d/luci-app-falter-service-registrar.json:14
+msgid "Set up Freifunk services"
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:66
+msgid "The FQDN of your website, i.e.: \"example.olsr\""
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:43
+msgid ""
+"The Fully-Qualified-Domain-Name of your website, i.e.: \"example.olsr\". "
+"This is URL on which your service will be available in the Freifunk network."
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:58
+msgid "Web Root"
+msgstr ""
+
+#: luci/luci-app-falter-service-registrar/htdocs/luci-static/resources/view/falter-service-registrar/form.js:34
+msgid "Websites"
+msgstr ""

--- a/luci/luci-app-falter-service-registrar/root/usr/share/luci/menu.d/luci-app-falter-service-registrar.json
+++ b/luci/luci-app-falter-service-registrar/root/usr/share/luci/menu.d/luci-app-falter-service-registrar.json
@@ -1,0 +1,21 @@
+{
+	"admin/freifunk/": {
+	  "title": "Freifunk",
+	  "order": 1,
+	  "action": {
+		"type": "firstchild"
+	  },
+	  "depends": {
+		"acl": [ "luci-app-falter-service-registrar" ]
+	  }
+	},
+
+	"admin/freifunk/service-registrar": {
+	  "title": "Set up Freifunk services",
+	  "order": 27,
+	  "action": {
+		"type": "view",
+		"path": "falter-service-registrar/form"
+	  }
+	}
+  }

--- a/luci/luci-app-falter-service-registrar/root/usr/share/rpcd/acl.d/luci-app-falter-service-registrar.json
+++ b/luci/luci-app-falter-service-registrar/root/usr/share/rpcd/acl.d/luci-app-falter-service-registrar.json
@@ -1,0 +1,25 @@
+{
+	"luci-app-falter-service-registrar": {
+	  "description": "Grant UCI access to LuCI app falter-service-registrar",
+	  "read": {
+		"ubus": {
+		  "uci": [
+			"get"
+		  ]
+		},
+		"uci": [
+		  "service-registrar"
+		]
+	  },
+	  "write": {
+		"ubus": {
+		  "uci": [
+			"set", "commit"
+		  ]
+		},
+		"uci": [
+		  "service-registrar"
+		]
+	  }
+	}
+  }

--- a/packages/falter-berlin-service-registrar/LICENSE
+++ b/packages/falter-berlin-service-registrar/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/packages/falter-berlin-service-registrar/Makefile
+++ b/packages/falter-berlin-service-registrar/Makefile
@@ -1,0 +1,53 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=falter-berlin-service-registrar
+PKG_VERSION:=0.2
+
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/falter-berlin-service-registrar/default
+  SECTION:=falter-berlin
+  CATEGORY:=falter-berlin
+  URL:=http://github.com/Freifunk-Spalter/packages
+  PKGARCH:=all
+  EXTRA_DEPENDS:=olsrd, olsrd-mod-nameservice, uhttpd, uci
+endef
+
+define Package/falter-berlin-service-registrar
+	$(call Package/falter-berlin-service-registrar/default)
+	TITLE:=Freifunk Berlin Service Registrar
+endef
+
+
+define Package/falter-berlin-service-registrar/description
+  App for simplifying the registration and anouncment of services in Freifunk Berlin Mesh-Network.
+endef
+
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/falter-berlin-service-registrar/conffiles
+/etc/config/ffservices
+endef
+
+define Package/falter-berlin-service-registrar/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) ./files/register-services.sh $(1)/usr/bin/register-services
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/ffservices.conf $(1)/etc/config/ffservices
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/ffserviced.sh $(1)/etc/init.d/ffserviced
+endef
+
+$(eval $(call BuildPackage,falter-berlin-service-registrar))

--- a/packages/falter-berlin-service-registrar/README.rst
+++ b/packages/falter-berlin-service-registrar/README.rst
@@ -1,0 +1,1 @@
+doc/falter-berlin-service-registrar.rst

--- a/packages/falter-berlin-service-registrar/doc/falter-berlin-service-registrar.rst
+++ b/packages/falter-berlin-service-registrar/doc/falter-berlin-service-registrar.rst
@@ -21,7 +21,7 @@ installiert.
 
 Falls man den Service-Registrar ausschließlich über die Kommandozeile nutzen möchte, geht auch ein ``opkg install falter-berlin-service-registrar``.
 
-Beide Varianten haben den gleicen Funktionsumfang und unterscheiden sich ausschließlich in der Bedienung.
+Beide Varianten haben den gleichen Funktionsumfang und unterscheiden sich ausschließlich in der Bedienung.
 
 
 LuCI-App (Webinterface)
@@ -29,7 +29,7 @@ LuCI-App (Webinterface)
 
 Der Service-Registrar befindet sich in der Admin-Oberfläche unter *Freifunk* -> *Freifunkdienste registrieren*. In der App können entweder Webseiten oder Allgemeine Dienste angelegt werden.
 
-Webeiten sind Dienste, bei denen der Freifunk-Router selbst eine (statische) Webseite ausliefert. Es wird also nicht nur entsprechend OLSR konfiguriert, sondern auch der Webserver auf dem Freifunkrouter so eingestellt, dass er die Webseite ausliefert.
+Webseiten sind Dienste, bei denen der Freifunk-Router selbst eine (statische) Webseite ausliefert. Es wird also nicht nur entsprechend OLSR konfiguriert, sondern auch der Webserver auf dem Freifunkrouter so eingestellt, dass er die Webseite ausliefert.
 
 Allgemeine Dienste sind etwas anders. Sie eignen für Dienste, die auf einem anderen Gerät im lokalen Freifunknetzwerk laufen. Wenn man z.B. eine Webcam bereitstellen möchte, oder irgendeine andere Art von Server hat, eignet sich diese Art von Diensten am besten dafür.
 
@@ -43,9 +43,9 @@ Bis der Service im kompletten Freifunknetz verfügbar ist, können bis zu 5 Minu
 Kommandozeile
 ^^^^^^^^^^^^^
 
-Um einen Dienst über die Kommondozeile einzutragen, muss zuerst die Konfigurationsdatei unter ``/etc/config/ffservices`` angepasst werden und anschließend das Skript ``register-services`` ausgeführt werden.
+Um einen Dienst über die Kommandozeile einzutragen, muss zuerst die Konfigurationsdatei unter ``/etc/config/ffservices`` angepasst werden und anschließend das Skript ``register-services`` ausgeführt werden.
 
-Je nachdem, ob man eine Webseite oder einen Allgemeinen Dienst eintragen möchte, gibt es zwei unterscheidliche Typen von UCI-Sections. Einmal den Typen ``website`` und einmal den Typen ``service``. Beide Typen unterscheiden sich geringfügig in ihren Feldern:
+Je nachdem, ob man eine Webseite oder einen Allgemeinen Dienst eintragen möchte, gibt es zwei unterschiedliche Typen von UCI-Sections. Einmal den Typen ``website`` und einmal den Typen ``service``. Beide Typen unterscheiden sich geringfügig in ihren Feldern:
 
 ..
     config website "testsite"

--- a/packages/falter-berlin-service-registrar/doc/falter-berlin-service-registrar.rst
+++ b/packages/falter-berlin-service-registrar/doc/falter-berlin-service-registrar.rst
@@ -1,0 +1,72 @@
+falter-berlin-service-registrar
+===============================
+
+Der Service-Registrar ist eine App, die die Einrichtung von Diensten im Berliner Freifunknetz stark vereinfacht. Die Anwendung besteht aus einer LuCI-App für das komfortable Anlegen der Dienste über die Weboberfläche und einem Shell-Script/Daemon, welcher die Eintragung der Dienste übernimmt.
+
+Gebrauchsanweisung
+------------------
+
+Der Service-Registrar kann sowohl von der Kommandozeile, als auch vom Webinterface genutzt werden. Die Konzepte sind dabei sehr ähnlich, nur die Bedienung ist anders.
+
+Er generiert die Einstellungen ausschließlich aus seinen eigenen Dateien. Dienste, die z.B. von Hand im OLSR-Daemon eingetragen wurden, werden entfernt, sofern sie nicht beim Service-Registrar eingetragen sind.
+
+Möchte man den Service-Registrar nutzen, muss man ihn als Zusatzpaket nachinstallieren. Das geht im Webinterface über *System* -> *Paketverwaltung*, wo man die Pakete
+
+..
+    falter-berlin-service-registrar
+    luci-app-falter-service-registrar
+    luci-i18n-falter-service-registrar-de
+
+installiert.
+
+Falls man den Service-Registrar ausschließlich über die Kommandozeile nutzen möchte, geht auch ein ``opkg install falter-berlin-service-registrar``.
+
+Beide Varianten haben den gleicen Funktionsumfang und unterscheiden sich ausschließlich in der Bedienung.
+
+
+LuCI-App (Webinterface)
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Der Service-Registrar befindet sich in der Admin-Oberfläche unter *Freifunk* -> *Freifunkdienste registrieren*. In der App können entweder Webseiten oder Allgemeine Dienste angelegt werden.
+
+Webeiten sind Dienste, bei denen der Freifunk-Router selbst eine (statische) Webseite ausliefert. Es wird also nicht nur entsprechend OLSR konfiguriert, sondern auch der Webserver auf dem Freifunkrouter so eingestellt, dass er die Webseite ausliefert.
+
+Allgemeine Dienste sind etwas anders. Sie eignen für Dienste, die auf einem anderen Gerät im lokalen Freifunknetzwerk laufen. Wenn man z.B. eine Webcam bereitstellen möchte, oder irgendeine andere Art von Server hat, eignet sich diese Art von Diensten am besten dafür.
+
+Am besten sollte die IP-Adresse des entsprechenden Gerätes dann auf statisch gestellt werden (unter *Status* -> *Übersicht* und dann im Abschnitt *Aktive DHCP-Leases* auf den Knopf *Auf statisch setzen* drücken).
+
+Die benötigten Felder sind sind eigentlich relativ selbsterklärend. Nachdem die Änderungen mit dem Knopf *Speichern & Anwenden* abgespeichert wurden, beginnt der Freifunkrouter mit der Einrichtung.
+
+Bis der Service im kompletten Freifunknetz verfügbar ist, können bis zu 5 Minuten vergehen.
+
+
+Kommandozeile
+^^^^^^^^^^^^^
+
+Um einen Dienst über die Kommondozeile einzutragen, muss zuerst die Konfigurationsdatei unter ``/etc/config/ffservices`` angepasst werden und anschließend das Skript ``register-services`` ausgeführt werden.
+
+Je nachdem, ob man eine Webseite oder einen Allgemeinen Dienst eintragen möchte, gibt es zwei unterscheidliche Typen von UCI-Sections. Einmal den Typen ``website`` und einmal den Typen ``service``. Beide Typen unterscheiden sich geringfügig in ihren Feldern:
+
+..
+    config website "testsite"
+            option fqdn         "testsite.olsr"
+            option description  "Webseite auf dem lokalen Router"
+            option protocol     "tcp"
+            option port         "81"
+            option web_root     "/tmp/www/testsite"
+            option disabled     0
+
+..
+    config service "extern"
+            option fqdn         "extern.olsr"
+            option description  "Ein Dienst der auf einem anderen Geraet lauft"
+            option protocol     "udp"
+            option port         "80"
+            option ip_addr      "10.36.0.34"
+            option disabled     0
+
+Besondere Vorsicht braucht es bei dem Feld ``description``: Dort sollten keine Sonderzeichen, wie z.B. Punkte``.``, Kommata``,``, Dollarzeichen ``$``, Umlaute usw. verwendet werden.
+
+Die IP-Adresse im Feld ``ip_addr`` muss aus dem Host-Network des eigenen Routers stammen ("DHCP-Adressen" aus der IP-Email).
+
+Nachdem die Datei entsprechend angepasst wurde, werden die Dienste mit einem Aufruf von ``register-services`` eingetragen. Dienste, die vorher von Hand im OLSR-Daemon eingetragen wurden, werden dabei **ohne Hinweis** entfernt.

--- a/packages/falter-berlin-service-registrar/files/ffserviced.sh
+++ b/packages/falter-berlin-service-registrar/files/ffserviced.sh
@@ -1,0 +1,21 @@
+#!/bin/sh /etc/rc.common
+
+# Just looks for changes in the config-file and applies them with a
+# one-time-run.
+
+USE_PROCD=1
+
+service_triggers() {
+    procd_add_reload_trigger "ffservices"
+}
+
+start_service() {
+    procd_open_instance [ffserviced]
+    procd_set_param command /usr/bin/register-services
+
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_set_param pidfile /var/run/ffserviced.pid
+    procd_set_param term_timeout 10
+    procd_close_instance
+}

--- a/packages/falter-berlin-service-registrar/files/ffserviced.sh
+++ b/packages/falter-berlin-service-registrar/files/ffserviced.sh
@@ -16,6 +16,6 @@ start_service() {
     procd_set_param stdout 1
     procd_set_param stderr 1
     procd_set_param pidfile /var/run/ffserviced.pid
-    procd_set_param term_timeout 10
+    procd_set_param term_timeout 60
     procd_close_instance
 }

--- a/packages/falter-berlin-service-registrar/files/ffservices.conf
+++ b/packages/falter-berlin-service-registrar/files/ffservices.conf
@@ -1,0 +1,19 @@
+# Some example configurations:
+#
+# config website "testsite"
+#         option fqdn         "testsite.olsr"
+#         option description  "Website on your local router"
+#         option protocol     "tcp"
+#         option port         "81"
+#         option web_root     "/tmp/www/testsite"
+#         option disabled     0
+#
+# config service "extern"
+#         option fqdn         "extern.olsr"
+#         # service-descriptions must not contain special characters like [.,$äöü], Umlaute and so on
+#         option description  "A service running on another host"
+#         option protocol     "udp"
+#         option port         "80"
+#         # The IP-Address must be in the dhcp-range of the router
+#         option ip_addr      "10.36.0.34"
+#         option disabled     0

--- a/packages/falter-berlin-service-registrar/files/register-services.sh
+++ b/packages/falter-berlin-service-registrar/files/register-services.sh
@@ -1,0 +1,239 @@
+#!/bin/sh
+# shellcheck shell=dash
+# shellcheck disable=SC2155
+
+# This software originates from Freifunk Berlin and simplyfies registering
+# services in OLSR. It is licensed under GNU General Public License v3.0 or later
+# Copyright (C) 2022   Martin Hübner
+
+# shellcheck source=/dev/null
+. /lib/functions.sh
+
+# ToDo: Website descriptions must not contain a comma!
+
+
+log() {
+    local msg="$1"
+    logger -t "ffserviced" -s "$msg"
+}
+
+# busybox doesn't include the rev-command. Thus implementing it by ourself.
+rev() {
+    while read -r var; do
+        # function taken from https://stackoverflow.com/a/34668251
+        rev=""
+        i=1
+
+        while [ "$i" -le "${#var}" ]; do
+            rev="$(echo "$var" | awk -v i="$i" '{print(substr($0,i,1))}')$rev"
+            : $((i += 1))
+        done
+
+        echo "$rev"
+    done
+}
+
+get_olsrd_nsplugin_index() {
+    # get anonymous section number of nameservice_plugin in olsrd-config
+    local ipversion="$1"
+
+    if [ "$ipversion" = 4 ]; then
+        uci show olsrd | grep nameservice | sed -e 's|.*\(\d\).*|\1|g'
+    elif [ "$ipversion" = 6 ]; then
+        uci show olsrd6 | grep nameservice | sed -e 's|.*\(\d\).*|\1|g'
+    else
+        log "cannot find olsrd-conf for IP version $ipversion."
+    fi
+}
+
+flush_nondefault_uhttpd_sections() {
+    local section_name="$1"
+
+    if [ "$section_name" != "main" ] && [ "$section_name" != "defaults" ]; then
+        # flush section
+        uci_remove uhttpd "$section_name"
+    fi
+}
+
+flush_olsrd_services() {
+    nsplugin=$(get_olsrd_nsplugin_index 4)
+
+    uci_remove olsrd @LoadPlugin["$nsplugin"] hosts
+    uci_remove olsrd @LoadPlugin["$nsplugin"] service
+}
+
+# This script will empty all entries made in the olsrd nameservice plugin
+# So only those entries will remain, that are handled by this script,
+flush_old_entries() {
+    config_load uhttpd
+    config_foreach flush_nondefault_uhttpd_sections
+
+    flush_olsrd_services
+}
+
+create_website_template() {
+    local path="$1"
+
+    mkdir -p "$path" || return 1
+    if [ ! -f "$path"/index.html ]; then
+        cat <<EOF >"$path"/index.html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>It works!</title>
+  </head>
+  <body>
+    <h1>It works!</h1>
+    <p>You've successfully registered your static web page as a service in the Freifunk Berlin network. You may replace this example page with your own static website now.</p>
+    <p>This file is located under the service root directory at $path/index.html</p>
+  </body>
+</html>
+EOF
+        if [ $? != 0 ]; then
+            return 1
+        fi
+    fi
+}
+
+register_website_at_uhttpd() {
+    # configure website in uhttpd
+    local uci_section="$1"
+    local fqdn="$2"
+    local port="$3"
+    local web_root="$4"
+
+    uci_add uhttpd uhttpd "$uci_section"
+    uci_add_list uhttpd "$uci_section" listen_http "0.0.0.0:$port"
+    uci_add_list uhttpd "$uci_section" listen_http "[::]:$port"
+    # ToDo: Test, that uci handles "/tmp/www/website//" correctly
+    uci_set uhttpd "$uci_section" home "$web_root/"
+    uci_set uhttpd "$uci_section" max_requests 5
+    uci_set uhttpd "$uci_section" max_connections 100
+}
+
+register_service_at_olsrd() {
+    local addr="$1"
+    local fqdn="$2"
+    local port="$3"
+    local protocol="$4"
+    local description="$5"
+    # ToDo: service.name.olsr should work too, need to work with reverse...
+    local hostname=$(echo "$fqdn" | rev | cut -d'.' -f 2- | rev | tr '.' '-')
+
+    host_announcment="$addr $hostname"
+    service_announcement="http://$fqdn:$port|$protocol|$description"
+
+    # get anonymous section number of nameservice_plugin in olsrd-config
+    nsplugin=$(get_olsrd_nsplugin_index 4)
+
+    # generate service entry in olsrd-config
+    uci_add_list olsrd @LoadPlugin["$nsplugin"] hosts "$host_announcment"
+    uci_add_list olsrd @LoadPlugin["$nsplugin"] service "$service_announcement"
+}
+
+apply_configs() {
+    uci commit uhttpd
+    uci_commit olsrd
+    /etc/init.d/uhttpd restart
+    /etc/init.d/olsrd restart
+    /etc/init.d/dnsmasq restart
+}
+
+handle_service() {
+    local uci_section="$1"
+
+    # 1. Name of a variable to store the retrieved value in
+    # 2. ID of the section to read the value from
+    # 3. Name of the option to read the value from
+    # 4. Default (optional), value to return instead if option is unset
+    # see https://openwrt.org/docs/guide-developer/config-scripting
+
+    config_get fqdn "$uci_section" fqdn
+    config_get description "$uci_section" description
+    config_get protocol "$uci_section" protocol "tcp"
+    config_get port "$uci_section" port "80"
+    config_get ip_addr "$uci_section" ip_addr
+    config_get disabled "$uci_section" disabled "0"
+
+    if [ "${disabled:?}" = 0 ]; then
+
+        if [ -z "$fqdn" ] || [ -z "$description" ] || [ -z "$ip_addr" ]; then
+            log "service configuration failed! UCI section $uci_section misses at least one of mandatory fqdn, description or ip_addr options"
+            # return 0 to allow configuration of other services
+            return 0
+        fi
+
+        log "registering service with
+    FQDN.................: $fqdn
+    Name/Description.....: $description
+    Protocol.............: $protocol
+    Port.................: $port
+    IP Address...........: $ip_addr"
+
+        register_service_at_olsrd "$ip_addr" "$fqdn" "$port" "$protocol" "$description"
+
+    fi
+}
+
+handle_website() {
+    local uci_section="$1"
+
+    # see https://openwrt.org/docs/guide-developer/config-scripting
+
+    config_get fqdn "$uci_section" fqdn
+    config_get description "$uci_section" description
+    config_get protocol "$uci_section" protocol "tcp"
+    config_get port "$uci_section" port "80"
+    config_get web_root "$uci_section" web_root
+    config_get disabled "$uci_section" disabled "0"
+
+    if [ "$disabled" = 0 ]; then
+
+        if [ -z "$fqdn" ] || [ -z "$description" ] || [ -z "$web_root" ]; then
+            log "service configuration failed! UCI section $uci_section misses at least one of mandatory fqdn, description or web_root options"
+            # return 0 to allow configuration of other services
+            return 0
+        fi
+
+        log "registering website with
+    FQDN.................: $fqdn
+    Name/Description.....: $description
+    Protocol.............: $protocol
+    Port.................: $port
+    Web root.............: $web_root"
+
+        create_website_template "$web_root"
+
+        register_website_at_uhttpd "$uci_section" "$fqdn" "$port" "$web_root"
+
+        website_addr=$(uci_get network dhcp ipaddr) # first IP addr of DHCP subnet
+        register_service_at_olsrd "$website_addr" "$fqdn" "$port" "$protocol" "$description"
+
+    fi
+
+}
+
+##########
+#  Main  #
+##########
+
+# check for config file
+if [ ! -f /etc/config/ffservices ]; then
+    echo "No configuration file found. Please define it under /etc/config/ffservices."
+    exit 2
+fi
+
+if [ -z "$(uci show ffservices | sed -e '/^#/d' )" ]; then
+    echo "/etc/config/ffservices seems to contain no configuration."
+    exit 2
+fi
+
+flush_old_entries
+
+config_load ffservices
+
+config_foreach handle_service service
+config_foreach handle_website website
+
+apply_configs


### PR DESCRIPTION
website-registrar is a tool meant to automatise the registration of services in the freifunk-berlin-network. Its in an early draft-state. Currently it supports registering a website wich is hosted in routers `/tmp/`-directory and gets delivered by OpenWrts uhttpd webserver.
