### PR TITLE
falter-berlin-tunnelmanager: increase timeout to register interface

### DIFF
--- a/packages/falter-berlin-tunnelmanager/files/tunnelman.sh
+++ b/packages/falter-berlin-tunnelmanager/files/tunnelman.sh
@@ -106,7 +106,7 @@ teardown() {
 wg_get_usage() {
     local server="$1"
     # ToDo: PASSWORDS!!!!11!!111!!
-    clients=$(timeout 5 ip netns exec $OPT_NAMESPACE_NAME wg-client-installer get_usage --endpoint "$server" --user wginstaller --password wginstaller)
+    clients=$(timeout 60 ip netns exec $OPT_NAMESPACE_NAME wg-client-installer get_usage --endpoint "$server" --user wginstaller --password wginstaller)
     if [ $? -ne 0 ]; then
         return 1
     fi


### PR DESCRIPTION
Should fix #280.

5 seconds seem to be to fast to register an interface. I suspect that
the client registers some interface, a timeout triggers, and the server
installed the interface. However, due to the timeout, the client excepts
that a failure occurs. That continues in a loop and will prevent a
client to connect to some gateway again. Increase timeout to 1 minute to
allow the client to have enough time to install the wireguard interface.

