### PR TITLE
falter-berlin-tunnelmanager: add option for mtu

### DIFF
--- a/packages/falter-berlin-tunnelmanager/Makefile
+++ b/packages/falter-berlin-tunnelmanager/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-berlin-tunnelmanager
-PKG_VERSION:=0.2
+PKG_VERSION:=0.3
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/packages/falter-berlin-tunnelmanager/files/tunnelmanager.config
+++ b/packages/falter-berlin-tunnelmanager/files/tunnelmanager.config
@@ -7,6 +7,7 @@
 #	option tunnel_count '1'
 #	option tunnel_timeout '160'
 #	option check_interval '30'
+#	option mtu '1412'
 #	option up_script '/usr/share/tunnelman/up.sh'
 #	option up_script_args '10.31.147.224/29'
 #	option down_script '/usr/share/tunnelman/down.sh'

--- a/packages/falter-berlin-tunnelmanager/files/tunnelmanager.init
+++ b/packages/falter-berlin-tunnelmanager/files/tunnelmanager.init
@@ -12,6 +12,9 @@ tm_start() {
     config_get _value "$instance" namespace
     local namespace="$_value"
 
+    config_get _value "$instance" mtu
+    local mtu="$_value"
+
     config_get _value "$instance" interface
     local interface="$_value"
 
@@ -41,7 +44,7 @@ tm_start() {
 
     procd_open_instance
     procd_set_param respawn 3600 5 0
-    procd_set_param command /bin/sh "/usr/bin/tunnelman" "-T 176.74.57.43" "-T" "176.74.57.19" "-T" "77.87.51.11" "-T" "77.87.49.8" "-n" "$namespace" "-i" "$interface" "-a" "$uplink_ip" "-g" "$uplink_gateway" "-c" "$tunnel_count" "-t" "$tunnel_timeout" "-o" "$check_interval" "-U" "$up_script" "-A" "$up_script_args" "-D" "$down_script"
+    procd_set_param command /bin/sh "/usr/bin/tunnelman" "-T 176.74.57.43" "-T" "176.74.57.19" "-T" "77.87.51.11" "-T" "77.87.49.8" "-n" "$namespace" "-m" "$mtu" "-i" "$interface" "-a" "$uplink_ip" "-g" "$uplink_gateway" "-c" "$tunnel_count" "-t" "$tunnel_timeout" "-o" "$check_interval" "-U" "$up_script" "-A" "$up_script_args" "-D" "$down_script"
     procd_set_param netdev "$interface"
     procd_close_instance
 }


### PR DESCRIPTION
Define mtu in the config that should be used in for the tunnel.
Sometimes you only have ppoe, however sometimes people have 4in6 and so
on. Different setups need different MTUs.