### PR TITLE
Poemgr

### DIFF
--- a/packages/poemgr/Makefile
+++ b/packages/poemgr/Makefile
@@ -1,17 +1,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=poemgr
-PKG_VERSION:=$(shell git show -s --format=%cd --date=short)
+PKG_SOURCE_DATE:=2022-03-21
+PKG_SOURCE_VERSION:=77395242f9b3cb6ef003c5ed74f9b5be78404450
 PKG_RELEASE:=1
 
-PKG_FILE_DEPENDS:=$(CURDIR)/../..
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL=https://github.com/blocktrron/poemgr.git
+PKG_MIRROR_HASH:=68034f886af8a4ebfd869af940510f755d660362a6069ac49c1ae6ce16cbd950
+
+PKG_MAINTAINER:=David Bauer <mail@david-bauer.net>
+PKG_LICENSE:=GPL-2.0-only
+
 
 include $(INCLUDE_DIR)/package.mk
-
-define Build/Prepare
-	mkdir -p $(PKG_BUILD_DIR)
-	cp -R $(CURDIR)/../../* $(PKG_BUILD_DIR)
-endef
 
 define Package/poemgr
   SECTION:=utils
@@ -23,10 +25,10 @@ endef
 define Package/poemgr/install
 	$(INSTALL_DIR) $(1)/sbin $(1)/usr/lib/poemgr/config $(1)/etc/config $(1)/etc/uci-defaults $(1)/etc/init.d
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/poemgr $(1)/sbin/poemgr
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/uswlite-pse-enable $(1)/usr/lib/poemgr/uswlite-pse-enable
-	$(CP) $(PKG_BUILD_DIR)/contrib/usw-lite.config $(1)/usr/lib/poemgr/config/usw-lite.config
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/uci-defaults.sh $(1)/etc/uci-defaults/99-poemgr
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/procd-init.sh $(1)/etc/init.d/poemgr
+	$(INSTALL_BIN) ./files/uswlite-pse-enable $(1)/usr/lib/poemgr/uswlite-pse-enable
+	$(CP) ./files/usw-lite.config $(1)/usr/lib/poemgr/config/usw-lite.config
+	$(INSTALL_BIN) ./files/uci-defaults.sh $(1)/etc/uci-defaults/99-poemgr
+	$(INSTALL_BIN) ./files/procd-init.sh $(1)/etc/init.d/poemgr
 endef
 
 

--- a/packages/poemgr/Makefile
+++ b/packages/poemgr/Makefile
@@ -1,0 +1,33 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=poemgr
+PKG_VERSION:=$(shell git show -s --format=%cd --date=short)
+PKG_RELEASE:=1
+
+PKG_FILE_DEPENDS:=$(CURDIR)/../..
+
+include $(INCLUDE_DIR)/package.mk
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+	cp -R $(CURDIR)/../../* $(PKG_BUILD_DIR)
+endef
+
+define Package/poemgr
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libuci +libjson-c
+  TITLE:=Control PoE ports on the UniFi Flex switch
+endef
+
+define Package/poemgr/install
+	$(INSTALL_DIR) $(1)/sbin $(1)/usr/lib/poemgr/config $(1)/etc/config $(1)/etc/uci-defaults $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/poemgr $(1)/sbin/poemgr
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/uswlite-pse-enable $(1)/usr/lib/poemgr/uswlite-pse-enable
+	$(CP) $(PKG_BUILD_DIR)/contrib/usw-lite.config $(1)/usr/lib/poemgr/config/usw-lite.config
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/uci-defaults.sh $(1)/etc/uci-defaults/99-poemgr
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/procd-init.sh $(1)/etc/init.d/poemgr
+endef
+
+
+$(eval $(call BuildPackage,poemgr))

--- a/packages/poemgr/files/procd-init.sh
+++ b/packages/poemgr/files/procd-init.sh
@@ -1,0 +1,36 @@
+#!/bin/sh /etc/rc.common
+
+START=80
+USE_PROCD=1
+
+NAME=poemgr
+PROG=/sbin/poemgr
+
+. /lib/functions.sh
+
+
+reload_service() {
+	start
+}
+
+service_triggers() {
+	procd_add_reload_trigger poemgr
+}
+
+stop_service()
+{
+	$PROG disable
+}
+
+start_service()
+{
+	DISABLED="$(uci -q get poemgr.settings.disabled)"
+	DISABLED="${DISABLED:-0}"
+
+	if [ "$DISABLED" -gt 0 ]
+	then
+		$PROG disable
+	else
+		$PROG apply
+	fi
+}

--- a/packages/poemgr/files/uci-defaults.sh
+++ b/packages/poemgr/files/uci-defaults.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+[ -e /etc/config/poemgr ] && exit 0
+
+. /lib/functions/uci-defaults.sh
+
+board=$(board_name)
+case "$board" in
+ubnt,usw-flex)
+    cp /usr/lib/poemgr/usw-flex.config /etc/config/poemgr
+    ;;
+esac

--- a/packages/poemgr/files/usw-lite.config
+++ b/packages/poemgr/files/usw-lite.config
@@ -1,0 +1,23 @@
+config poemgr 'settings'
+        option profile 'usw-flex'
+        option disabled '1'
+
+config port 'lan2'
+        option name 'lan2'
+        option port '3'
+        option disabled '1'
+
+config port 'lan3'
+        option name 'lan3'
+        option port '2'
+        option disabled '1'
+
+config port 'lan4'
+        option name 'lan4'
+        option port '1'
+        option disabled '1'
+
+config port 'lan5'
+        option name 'lan5'
+        option port '0'
+        option disabled '1'

--- a/packages/poemgr/files/uswlite-pse-enable
+++ b/packages/poemgr/files/uswlite-pse-enable
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+echo 487 > /sys/class/gpio/export # JK
+echo 488 > /sys/class/gpio/export # CLK
+
+echo out > /sys/class/gpio/gpio487/direction
+echo out > /sys/class/gpio/gpio488/direction
+
+echo $1 > /sys/class/gpio/gpio487/value
+echo 0 > /sys/class/gpio/gpio488/value
+echo 1 > /sys/class/gpio/gpio488/value


### PR DESCRIPTION
Maintainer: @pktpls / original package author: blocktrron / David Bauer
Compile tested: mt7621, USW-Flex, openwrt-snapshot
Run tested: mt7621, USW-Flex, openwrt-snapshot, tests: enabled/disabled/configured the PoE chip, successfully powered up one 802.3af device, integrated into bbb-configs

Description:

Dies ist ein Import des poemgr Pakets von blocktrron, das noch keinem sonstigen Feed zugeordnet ist. Auf lange Sicht wäre es sicher gut, wenn das Paket im default OpenWrt-packages-Feed landet, dann kann es hier wieder entfernt werden.

Ich brauchs für den Unifi Switch Flex, ein Outdoor 4-Port-PoE-Switch, mglw. eine Alternative zum Edgepoint R6, der auf absehbare Zeit nicht lieferbar ist.

Einfache Aktivierung via gpio pins wie bei Passive PoE reicht hier nicht, weil es ein vollwertiger 802.3af/at/bt chip ist.