### PR TITLE
falter-berlin-autoupdate: add some checks and refinements

### DIFF
--- a/packages/falter-berlin-autoupdate/files/lib_autoupdate.sh
+++ b/packages/falter-berlin-autoupdate/files/lib_autoupdate.sh
@@ -10,6 +10,8 @@
 # work anyway. This is a little reminder to you, if you use some rare shell without
 # a builtin "local" statement.
 
+set -o pipefail
+
 log() {
     local msg="$1"
     logger -t autoupdater -s "$msg"
@@ -107,7 +109,7 @@ request_file_size() {
 
     size_bytes=$(printf "GET $file HTTP/1.0\r\nHost: $fqdn\r\nConnection: close\r\n\r\n" | nc "$fqdn" 80 | head | grep "Content-Length" | cut -d':' -f2)
 
-    return $(( size_bytes / 1024))
+    return $((size_bytes / 1024))
 }
 
 get_download_link_and_hash() {

--- a/packages/falter-berlin-autoupdate/files/post-inst.sh
+++ b/packages/falter-berlin-autoupdate/files/post-inst.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 #
 
-#if autoupdate is not present in crontab, include it.
-crontab -l | grep /usr/bin/autoupdate >> /dev/null
+# if autoupdate is not present in crontab, include it.
+crontab -l | grep /usr/bin/autoupdate >>/dev/null
 if [ $? != 0 ]; then
-    #get a fairly random update-time, to protect the servers from DoS
-    HOUR=$(($(tr -cd 0-9 </dev/urandom | head -c 2) % 24))
+    # get a fairly random update-time, to protect the servers from DoS. Will be something between 3 and 5 a.m.
+    HOUR=$((($(tr -cd 0-9 </dev/urandom | head -c 2) % 3) + 3))
     MIN=$(($(tr -cd 0-9 </dev/urandom | head -c 2) % 60))
-    echo "$MIN $HOUR * * *        /usr/bin/autoupdate" >> /etc/crontabs/root
-    
-	/etc/init.d/cron restart
+    echo "$MIN $HOUR * * *        /usr/bin/autoupdate" >>/etc/crontabs/root
+
+    /etc/init.d/cron restart
 fi


### PR DESCRIPTION
This adds some further checks. For example, nodes with development
firmware shouldn't perfom an auto-update.

Signed-off-by: Martin Hübner <martin.hubner@web.de>
