### PR TITLE
falter-berlin-autoupdate: minor fixes

### DIFF
--- a/packages/falter-berlin-autoupdate/files/autoupdate.sh
+++ b/packages/falter-berlin-autoupdate/files/autoupdate.sh
@@ -100,7 +100,7 @@ log "starting autoupdate..."
 ##################
 #  Update-stuff
 
-if echo "$FREIFUNK_RELEASE" | grep "snapshot"; then
+if ! echo "$FREIFUNK_RELEASE" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'; then
     log "automatic updates aren't supported for development-firmwares. Please update manually."
     exit 2
 fi

--- a/packages/falter-berlin-autoupdate/files/post-inst.sh
+++ b/packages/falter-berlin-autoupdate/files/post-inst.sh
@@ -5,8 +5,8 @@
 crontab -l | grep /usr/bin/autoupdate >>/dev/null
 if [ $? != 0 ]; then
     # get a fairly random update-time, to protect the servers from DoS. Will be something between 3 and 5 a.m.
-    HOUR=$((($(tr -cd 0-9 </dev/urandom | head -c 2) % 3) + 3))
-    MIN=$(($(tr -cd 0-9 </dev/urandom | head -c 2) % 60))
+    HOUR=$(( ($( dd if=/dev/urandom bs=2 count=1 2>&- | hexdump | if read line; then echo 0x${line#* }; fi ) % 3) + 3))
+    MIN=$(( $( dd if=/dev/urandom bs=2 count=1 2>&- | hexdump | if read line; then echo 0x${line#* }; fi ) % 59))
     echo "$MIN $HOUR * * *        /usr/bin/autoupdate" >>/etc/crontabs/root
 
     /etc/init.d/cron restart


### PR DESCRIPTION
There was an error in the random-stuff which resulted in that sometimes
the initialisation of the random update-time failed.
Aditionally also exclude rc-candidates by using regex.

Signed-off-by: Martin Hübner <martin.hubner@web.de>

Please cherry-pick to `Openwrt-21.02-branch` too.