### PR TITLE
falter-berlin-autoupdate: only call autoupdate if it exists

### DIFF
--- a/packages/falter-berlin-autoupdate/files/post-inst.sh
+++ b/packages/falter-berlin-autoupdate/files/post-inst.sh
@@ -7,7 +7,7 @@ if [ $? != 0 ]; then
     # get a fairly random update-time, to protect the servers from DoS. Will be something between 3 and 5 a.m.
     HOUR=$(( ($( dd if=/dev/urandom bs=2 count=1 2>&- | hexdump | if read line; then echo 0x${line#* }; fi ) % 3) + 3))
     MIN=$(( $( dd if=/dev/urandom bs=2 count=1 2>&- | hexdump | if read line; then echo 0x${line#* }; fi ) % 59))
-    echo "$MIN $HOUR * * *        /usr/bin/autoupdate" >>/etc/crontabs/root
+    echo "$MIN $HOUR * * *       test -e /usr/bin/autoupdate && /usr/bin/autoupdate" >>/etc/crontabs/root
 
     /etc/init.d/cron restart
 fi


### PR DESCRIPTION
Add test in crontab to call autoupdate only, if the script exists.

Signed-off-by: Martin Hübner <martin.hubner@web.de>
