### PR TITLE
falter-berlin-tunnelmanager: fix available ips calculation

### DIFF
--- a/packages/falter-berlin-tunnelmanager/files/up.sh
+++ b/packages/falter-berlin-tunnelmanager/files/up.sh
@@ -96,7 +96,7 @@ get_ips_from_prefix "$prefix"
 # unconditionally wipe all configured ips from available ips.
 available_ips="$_ret_prefixes"
 for i in $(get_configured_ips); do
-    available_ips="$(echo $available_ips | sed "s/$i//")"
+    available_ips="$(echo $available_ips | sed "s/\b$i\b//")"
 done
 
 next_ip="$(echo $available_ips | awk '{print $1}')"


### PR DESCRIPTION
If a configured ip matches a part of an available it results in this:
  echo 10.22.112.16 | sed "s/10.22.112.1//"
  -> 6
and the ip 6.0.0.0/32 will be assigned.
