### PR TITLE
falter-berlin-olsrd-defaults: add option filewrite (nameservice-plugin)

### DIFF
--- a/packages/falter-berlin-olsrd-defaults/uci-defaults/freifunk-berlin-olsrd-defaults
+++ b/packages/falter-berlin-olsrd-defaults/uci-defaults/freifunk-berlin-olsrd-defaults
@@ -24,6 +24,7 @@ uci set olsrd.$PLUGIN.suffix=.olsr
 uci set olsrd.$PLUGIN.hosts_file=/tmp/hosts/olsr
 uci set olsrd.$PLUGIN.latlon_file=/var/run/latlon.js
 uci set olsrd.$PLUGIN.services_file=/var/etc/services.olsr
+uci set olsrd.$PLUGIN.filewrite_interval=300
 
 # add jsoninfo plugin
 PLUGIN="$(uci add olsrd LoadPlugin)"


### PR DESCRIPTION
The hosts-file was read regularily, but not written out to disk. The
amendment of the filewrite_interval option in olsrd-nameservice plugin
should fix this.

Fixes #296.

Signed-off-by: Martin Hübner <martin.hubner@web.de>

Please cherry-pick to openWrt-21.02 too.
