### PR TITLE
falter-berlin-autoupdate-keys: add key of pktpls

### DIFF
--- a/packages/falter-berlin-autoupdate/keys/schmars.pub
+++ b/packages/falter-berlin-autoupdate/keys/schmars.pub
@@ -1,0 +1,2 @@
+untrusted comment: Freifunk firmware signing key of pktpls@systemli.org
+RWQgzQ1zsbgKas7ek4XfDRhebhEMMZg42lL/bKwXDm/J3VEFI1kikB2Y


### PR DESCRIPTION
Add the pubkey of pktpls as a valid key for signing autoupdates.

Signed-off-by: Martin Hübner <martin.hubner@web.de>
