### PR TITLE
luci-mod-falter: fix Typo in index-page

### DIFF
--- a/luci/luci-mod-falter/luasrc/view/freifunk/index.htm
+++ b/luci/luci-mod-falter/luasrc/view/freifunk/index.htm
@@ -44,7 +44,7 @@ end
 <%
 
 local co = "profile_" .. community
---local community = uci:get_first(co, "community", "name") or "Freifunk"
+local community = uci:get_first(co, "community", "name") or "Freifunk"
 local url = uci:get_first(co, "community", "homepage") or "http://www.freifunk.net"
 
 


### PR DESCRIPTION
A fellow Freifunka spotted an typing issue in the welcome-page,
which should be fixed with this.

https://lists.berlin.freifunk.net/pipermail/berlin/2022-May/053051.html

Signed-off-by: Martin Hübner <martin.hubner@web.de>
