### PR TITLE
falter-berlin-firewall-defaults: migrating to fw4

### DIFF
--- a/packages/falter-berlin-firewall-defaults/Makefile
+++ b/packages/falter-berlin-firewall-defaults/Makefile
@@ -10,7 +10,7 @@ define Package/falter-berlin-firewall-defaults
   CATEGORY:=falter-berlin
   TITLE:=Freifunk Berlin firewall default configuration
   URL:=http://github.com/freifunk-berlin/packages_berlin
-  EXTRA_DEPENDS:=firewall, falter-berlin-lib-guard
+  EXTRA_DEPENDS:=firewall4, falter-berlin-lib-guard
   PKGARCH:=all
 endef
 


### PR DESCRIPTION
OpenWrt-22.03 will use firewall4 for firewall configuration. According
to the release notes, there should be no difference in th uci configuratiuon
files, so that old defaults should still work.

Signed-off-by: Martin Hübner <martin.hubner@web.de>

## This must not be cherry-picked to 21.02. It would brake things!

https://openwrt.org/releases/22.03/notes-22.03.0-rc1#firewall4_based_on_nftables