### PR TITLE
falter-berlin-ssid-changer: use dns server from config

### DIFF
--- a/packages/falter-berlin-ssid-changer/files/hotplug.d/30-ssid-changer
+++ b/packages/falter-berlin-ssid-changer/files/hotplug.d/30-ssid-changer
@@ -1,11 +1,12 @@
 #!/bin/sh
 
+# shellcheck shell=dash
+
 # kept for debugging purpose
 # logger -t "ssid net/hotplug" "ssidchanger ACTION = $ACTION INTERFACE = $INTERFACE DEVICE = $DEVICE IFUPDATE_ADDRESSES = $IFUPDATE_ADDRESSES IFUPDATE_DATA = $IFUPDATE_DATA"
 
 . /lib/functions.sh
 . /lib/lib_ssid-changer.sh
-
 
 # exit early, if ssid-changer is disabled or interface doesn't matter for wifi
 ENABLED=$(uci_get ffwizard ssid_changer enabled)
@@ -17,7 +18,6 @@ if [ "$INTERFACE" != "ffuplink" ] || !(echo "$INTERFACE" | grep -Eq 'tnl_.*'); t
     exit 0
 fi
 
-
 # check, if we are online
 is_internet_reachable # 0 success - online; 1 failure - offline
 NET_STATE=$?
@@ -26,11 +26,11 @@ ONLINE_SSIDS=$(get_interfaces)
 CHK_SSID=$(echo "$ONLINE_SSIDS" | cut -d' ' -f 1) # makes checking easier
 CHANGE=0
 
-
 if [ $NET_STATE = 0 ]; then # router online: switch to online, if not present already
     # abort if SSID is "online" already
-    for HOSTAPD in $(ls /var/run/hostapd-phy*); do
-        CURRSSID=$(grep -e "^ssid=" $HOSTAPD | cut -d'=' -f 2)
+    for HOSTAPD in /var/run/hostapd-phy*; do
+        [ -e "$HOSTAPD" ] || break
+        CURRSSID=$(grep -e "^ssid=" "$HOSTAPD" | cut -d'=' -f 2)
         if [ "$CURRSSID" = "$CHK_SSID" ]; then
             log "SSID online already. Nothing to change."
             exit 0
@@ -38,17 +38,19 @@ if [ $NET_STATE = 0 ]; then # router online: switch to online, if not present al
     done
 
     # loop over hostapd configs and try to switch any matching ID.
-    for HOSTAPD in $(ls /var/run/hostapd-phy*); do
+    for HOSTAPD in /var/run/hostapd-phy*; do
+        [ -e "$HOSTAPD" ] || break
         for ONLINE_SSID in $ONLINE_SSIDS; do
             log "Internet was reached. Change SSID back to online..."
-            sed -i "s~^ssid=$OFFLINE_SSID~ssid=$ONLINE_SSID~" $HOSTAPD
+            sed -i "s~^ssid=$OFFLINE_SSID~ssid=$ONLINE_SSID~" "$HOSTAPD"
             CHANGE=1
         done
     done
 else # router offline: adjust ssid accordingly, if needed
     # abort if SSID is "offline" already
-    for HOSTAPD in $(ls /var/run/hostapd-phy*); do
-        CURRSSID=$(grep -e "^ssid=" $HOSTAPD | cut -d'=' -f2)
+    for HOSTAPD in /var/run/hostapd-phy*; do
+        [ -e "$HOSTAPD" ] || break
+        CURRSSID=$(grep -e "^ssid=" "$HOSTAPD" | cut -d'=' -f2)
         if [ "$CURRSSID" = "$OFFLINE_SSID" ]; then
             log "SSID offline already. Nothing to change."
             exit 0
@@ -56,10 +58,11 @@ else # router offline: adjust ssid accordingly, if needed
     done
 
     # loop over hostapd configs and try to switch any matching ID.
-    for HOSTAPD in $(ls /var/run/hostapd-phy*); do
+    for HOSTAPD in /var/run/hostapd-phy*; do
+        [ -e "$HOSTAPD" ] || break
         for ONLINE_SSID in $ONLINE_SSIDS; do
             log "Didn't reach the internet. Change SSID to offline..."
-            sed -i "s~^ssid=$ONLINE_SSID~ssid=$OFFLINE_SSID~" $HOSTAPD
+            sed -i "s~^ssid=$ONLINE_SSID~ssid=$OFFLINE_SSID~" "$HOSTAPD"
         done
     done
 fi

--- a/packages/falter-berlin-ssid-changer/files/lib/lib_ssid-changer.sh
+++ b/packages/falter-berlin-ssid-changer/files/lib/lib_ssid-changer.sh
@@ -1,11 +1,14 @@
 #/bin/sh
+
+# shellcheck shell=dash
+# shellcheck disable=SC2155
+
 . /lib/functions.sh
 . /lib/functions/network.sh
 
-DNS_SERVER="8.8.8.8 1.1.1.1 9.9.9.9"
-NODENAME=$(uci_get system @system[-1] hostname | cut -b -24 ) # cut nodename to not exceed 32 bytes
-OFFLINE_SSID="offline_""$NODENAME"
-
+DNS_SERVER=$(uci_get network loopback dns)
+NODENAME=$(uci_get system @system[-1] hostname | cut -b -24) # cut nodename to not exceed 32 bytes
+export OFFLINE_SSID="offline_""$NODENAME"
 
 log() {
     logger -s -t "ssid-changer" -p 5 "$1"
@@ -14,17 +17,16 @@ log() {
 increment_ip_addr() {
     local raw_addr="$1"
 
-    local net=$(echo $raw_addr | cut -d'.' -f -3)
-    local host=$(echo $raw_addr | cut -d'.' -f 4)
-    host=$(( $host + 1 ))
+    local net=$(echo "$raw_addr" | cut -d'.' -f -3)
+    local host=$(echo "$raw_addr" | cut -d'.' -f 4)
+    host=$((host + 1))
     echo "$net"".$host"
 }
 
 is_internet_reachable_via_ffuplink() {
     # check if clients could reach the internet via ffuplink (only exists if we have a wan port)
     for SERVER in $DNS_SERVER; do
-        ping -c1 -W 3 -I ffuplink $SERVER > /dev/null
-        if [ $? = 0 ]; then
+        if ping -c1 -W 3 -I ffuplink "$SERVER" >/dev/null; then
             return 0
         fi
     done
@@ -35,10 +37,9 @@ exists_route_over_mesh() {
     # if internet not reachable via ffuplink, is there no route over the mesh either?
     local dhcp
     network_get_ipaddr dhcp dhcp
-    dhcp=$(increment_ip_addr $dhcp)
+    dhcp=$(increment_ip_addr "$dhcp")
     for SERVER in $DNS_SERVER; do
-        ip r g $SERVER from $dhcp iif br-dhcp
-        if [ $? = 0 ]; then # theres a route to the internet.
+        if ip r g "$SERVER" from "$dhcp" iif br-dhcp; then # theres a route to the internet.
             return 0
         fi
     done
@@ -59,7 +60,7 @@ is_internet_reachable() {
 get_interfaces() {
     # get the names of every interface named *dhcp* and fetch its normal ssid. Thus we get
     # 2.4 and/or 5 GHz both
-    local IFACES=$(uci show wireless | grep -e "dhcp.*\.ssid='.*\.freifunk.net'" | cut -d'=' -f1 )
+    local IFACES=$(uci show wireless | grep -e "dhcp.*\.ssid='.*\.freifunk.net'" | cut -d'=' -f1)
     local ONLINE_SSIDS=""
     for IFACE in $IFACES; do
         local SSID=$(uci_get "$IFACE")


### PR DESCRIPTION
Instead of hardcoding the dns servers of big dns providers, we should use
the dns servers configured for checking internet connectivity.
This prevents the case, where clients can't reach the internet, as these
servers are not reachable, but the big servers are.

Applies some shellcheck-issues additionally.

Fixes #309

Signed-off-by: Martin Hübner <martin.hubner@web.de>
