### PR TITLE
Fix/306

### DIFF
--- a/packages/falter-common/files-common/etc/config/freifunk
+++ b/packages/falter-common/files-common/etc/config/freifunk
@@ -112,7 +112,7 @@ config 'defaults' 'wifi_iface_5'
 
 config 'defaults' 'interface'
 	option 'netmask' '255.255.0.0'
-	option 'dns' '8.8.8.8 212.204.49.83 141.1.1.1'
+	option 'dns' '8.8.8.8 141.1.1.1'
 
 config 'defaults' 'alias'
 	option 'netmask' '255.255.255.0'

--- a/packages/falter-profiles/files/etc/config/profile_berlin
+++ b/packages/falter-profiles/files/etc/config/profile_berlin
@@ -36,7 +36,7 @@ config 'defaults' 'wifi_iface_80211s'
 
 config 'defaults' 'interface'
 	option 'netmask' '255.255.255.255'
-	option 'dns' '46.182.19.48 80.67.169.40 194.150.168.168 2001:4ce8::53 2001:910:800::12 2a02:2970:1002::18'
+	option 'dns' '46.182.19.48 80.67.169.40 194.150.168.168 9.9.9.10 149.112.112.10 2001:910:800::12 2a02:2970:1002::18 2620:fe::10 2620:fe::fe:10'
 
 config 'dhcp' 'dhcp'
 	option leasetime '5m'

--- a/packages/falter-profiles/files/etc/config/profile_cottbus
+++ b/packages/falter-profiles/files/etc/config/profile_cottbus
@@ -31,7 +31,7 @@ config 'defaults' 'ssidscheme'
 
 config 'defaults' 'interface'
 	option 'netmask' '255.255.255.255'
-	option 'dns' '46.182.19.48 80.67.169.40 194.150.168.168 2001:4ce8::53 2001:910:800::12 2a02:2970:1002::18'
+	option 'dns' '46.182.19.48 80.67.169.40 194.150.168.168 9.9.9.10 149.112.112.10 2001:910:800::12 2a02:2970:1002::18 2620:fe::10 2620:fe::fe:10'
 
 config 'dhcp' 'dhcp'
 	option 'leasetime' '5m'

--- a/packages/falter-profiles/files/etc/config/profile_fuerstenwalde
+++ b/packages/falter-profiles/files/etc/config/profile_fuerstenwalde
@@ -32,7 +32,7 @@ config 'defaults' 'ssidscheme'
 
 config 'defaults' 'interface'
 	option 'netmask' '255.255.255.255'
-	option 'dns' '46.182.19.48 80.67.169.40 194.150.168.168 2001:4ce8::53 2001:910:800::12 2a02:2970:1002::18'
+	option 'dns' '46.182.19.48 80.67.169.40 194.150.168.168 9.9.9.10 149.112.112.10 2001:910:800::12 2a02:2970:1002::18 2620:fe::10 2620:fe::fe:10'
 
 config 'dhcp' 'dhcp'
 option leasetime '5m'


### PR DESCRIPTION
This adds some dns servers of quad9 to the wizard profiles of the
communities in Berlin, Fürstenwalde and Cottbus.

We explicitly chose not the normal, filtered quad9-dns, but the
unfiltered one.

Additionally removes broken `2001:4ce8::53` service.

Fixes https://github.com/freifunk-berlin/falter-packages/issues/306.

Signed-off-by: Martin Hübner <martin.hubner@web.de>