### PR TITLE
gitignore: Add vscode-rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /build
-
+.vscode/


### PR DESCRIPTION
The .vscode directories should be ignored.

Signed-off-by: Martin Hübner <martin.hubner@web.de>