### PR TITLE
falter-berlin-tunnelmanager: fix deletion of wireguard interface

### DIFF
--- a/packages/falter-berlin-tunnelmanager/files/down.sh
+++ b/packages/falter-berlin-tunnelmanager/files/down.sh
@@ -17,3 +17,5 @@ uci delete "$section"
 uci delete "$filter"
 uci commit babeld
 /etc/init.d/babeld reload
+
+ip link del $interface


### PR DESCRIPTION
The wireguard interface is not removed if the tunnel has a timeout.
