### PR TITLE
tunnelmanager: start it earlier

### DIFF
--- a/packages/falter-berlin-tunnelmanager/files/tunnelmanager.init
+++ b/packages/falter-berlin-tunnelmanager/files/tunnelmanager.init
@@ -2,8 +2,8 @@
 
 USE_PROCD=1
 
-START=95
-STOP=01
+START=40
+STOP=10
 
 tm_start() {
     local instance="$1"


### PR DESCRIPTION
Maintainer: @PolynomialDivision 
Compile tested: -
Run tested: 22.03-snapshot @ firecracker x86-64

Description:

We want a working tunnel as fast as possible, but 95 is pretty late in the boot process. network is at 20 and olsrd/babel at 65/70, so 40 should be fine.

Also stop a little later - tunnelmanager doesn't need to be among the first services that are stopped.

Reduces time-to-tunnel in a VM from 1m20s to 15s