### PR TITLE
athwatch: add watchdog for ath10k wifi bug

### DIFF
--- a/packages/athwatch/Makefile
+++ b/packages/athwatch/Makefile
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2022 Packet Please <pktpls@systemli.org>
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=athwatch
+PKG_VERSION:=1
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_MAINTAINER:=Packet Please <pktpls@systemli.org>
+PKG_LICENSE:=GPL-2.0-only
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/athwatch
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Watchdog for ath10k wifi bugs
+  PKGARCH:=all
+endef
+
+define Package/athwatch/description
+Reboots when a certain ath10k_pci bug is detected.
+endef
+
+define Build/Compile
+endef
+
+define Package/athwatch/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/athwatch.init $(1)/etc/init.d/athwatch
+endef
+
+$(eval $(call BuildPackage,athwatch))

--- a/packages/athwatch/files/athwatch.init
+++ b/packages/athwatch/files/athwatch.init
@@ -1,0 +1,14 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=95
+STOP=01
+
+start_service() {
+    procd_open_instance
+
+    # This leaks child processes :-)
+    procd_set_param command /bin/sh -c '/sbin/logread -f | while read line ; do if $(echo -n "$line" | grep -q "ath10k.*failed to send pdev bss"); then logger -t athwatch "unrecoverable wifi bug detected, rebooting..." ; reboot ; fi ; sleep 60 ; done'
+
+    procd_close_instance
+}


### PR DESCRIPTION
Maintainer: me
Compile tested: EAP225-Outdoor, OpenWrt 22.03-SNAPSHOT
Run tested: EAP225-Outdoor, OpenWrt 22.03-SNAPSHOT

Description:

An attempt at a workaround for freifunk-berlin/bbb-configs#117 - tails `logread` for any occurence of "failed to send pdev bss" and then reboots. Unforunately it looks like a simple rmmod/modprobe cycle can throw the driver and firmware completely off the rails...