### PR TITLE
Two small tunnelmanager fixes

### DIFF
--- a/packages/falter-berlin-tunnelmanager/files/tunnelman.sh
+++ b/packages/falter-berlin-tunnelmanager/files/tunnelman.sh
@@ -69,11 +69,14 @@ setup_namespace() {
 
     if ! ip link add "$final_uplink_interface" link "$uplink_interface" type macvlan mode bridge; then
         log "Error while setting up macvlan-based uplink interface $final_uplink_interface attached to $uplink_interface"
+        ip netns del "$namespace_name"
         exit 1
     fi
 
     if ! ip link set dev "$final_uplink_interface" netns "$namespace_name"; then
         log "Error while moving uplink interface $final_uplink_interface attached to $uplink_interface"
+        ip netns del "$namespace_name"
+        ip link del "$final_uplink_interface"
         exit 1
     fi
 

--- a/packages/falter-berlin-tunnelmanager/files/tunnelmanager.init
+++ b/packages/falter-berlin-tunnelmanager/files/tunnelmanager.init
@@ -2,7 +2,7 @@
 
 USE_PROCD=1
 
-START=40
+START=55
 STOP=10
 
 tm_start() {


### PR DESCRIPTION
Maintainer: @PolynomialDivision 
Compile tested: ipq40xx
Run tested: ipq40xx

Description:

It turns out that START=40 is a little too early, often times netifd hasn't brought up all interfaces yet. As a result, we can't create the macvlan sub-interface of br-uplink yet and tunnelman.sh aborts. START=55 is better, but ideally we'd give some option to procd to wait for the network to be ready.

The early abort mentioned above led to an unreconverable state because the network namespace was left behind. There might be more spots for cleanup, but these two here already help.

With this cleanup, the too-early startup mentioned above is not a big deal anymore, since procd will simply try restarting tunnelman.sh after a short while.