### PR TITLE
fetch_translation_tools.sh: adjust translation tool downloader

### DIFF
--- a/fetch_translation_tools.sh
+++ b/fetch_translation_tools.sh
@@ -7,15 +7,11 @@ LUCI_ZIP="https://github.com/openwrt/luci/archive/refs/heads/master.zip"
 
 DIR="_tmp_"
 
-rm -rf build/
+git clean -df build/
 mkdir $DIR
 cd $DIR
 wget "$LUCI_ZIP"
 unzip "master.zip"
-mv luci-master/build ..
+mv luci-master/build/* ../build
 cd ..
 rm -rf $DIR
-
-#git clone $LUCI_REPO _tmp_
-#mv _tmp_/build .
-#rm -rf _tmp_


### PR DESCRIPTION
With the new repo-builder-script, build-dir will hold some other scripts, which we want to keep. Adjust translation fetcher to take care of that.

Signed-off-by: Martin Hübner <martin.hubner@web.de>

This commit depends on #338 
