### PR TITLE
Change wizard base-lang to english

### DIFF
--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua
@@ -24,19 +24,19 @@ for v in fs.glob(profiles.."*") do
   community:value(n, name)
 end
 
-hostname = f:field(Value, "hostname", translate("Name dieses Freifunk-Knotens"), "")
+hostname = f:field(Value, "hostname", translate("Name of this Freifunk node"), "")
 hostname.datatype = "hostname"
 function hostname.cfgvalue(self, section)
   return uci:get_first("system", "system","hostname") or sys.hostname()
 end
 
-nickname = f:field(Value, "nickname", translate("Dein Nickname"),"")
+nickname = f:field(Value, "nickname", translate("Your Nickname"),"")
 nickname.datatype = "string"
 function nickname.cfgvalue(self, section)
   return uci:get("freifunk", "contact", "nickname")
 end
 
-realname = f:field(Value, "realname", translate("Dein Realname"),"")
+realname = f:field(Value, "realname", translate("Your Realname"),"")
 realname.datatype = "string"
 function realname.cfgvalue(self, section)
   return uci:get("freifunk", "contact", "name")
@@ -48,25 +48,25 @@ function mail.cfgvalue(self, section)
   return uci:get("freifunk", "contact", "mail")
 end
 
-location = f:field(Value, "location", translate("Standort"), "")
+location = f:field(Value, "location", translate("Location"), "")
 location.datatype = "string"
 function location.cfgvalue(self, section)
   return uci:get_first("system", "system", "location") or uci:get("freifunk", "contact", "location")
 end
 
-lat = f:field(Value, "lat", translate("Geographischer Breitengrad"), "")
+lat = f:field(Value, "lat", translate("Latitude"), "")
 lat.datatype = "float"
 function lat.cfgvalue(self, section)
   return uci:get_first("system", "system","latitude")
 end
 
-lon = f:field(Value, "lon", translate("Geographischer Längengrad"), "")
+lon = f:field(Value, "lon", translate("Longitude"), "")
 lon.datatype = "float"
 function lon.cfgvalue(self, section)
   return uci:get_first("system", "system","longitude")
 end
 
-alt = f:field(Value, "alt", translate("Höhe über Grund"), "")
+alt = f:field(Value, "alt", translate("Height above the ground"), "")
 alt.datatype = "float"
 function alt.cfgvalue(self, section)
   return uci:get_first("system", "system","altitude")

--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/optionalConfigs.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/optionalConfigs.lua
@@ -23,7 +23,7 @@ css.template = "freifunk/assistent/snippets/css"
 enableStatsInfo = f:field(DummyValue, "statsInfo", "")
 enableStatsInfo.template = "freifunk/assistent/snippets/enableStats"
 
-enableStats = f:field(Flag, "stats", translate("Monitoring anschalten"))
+enableStats = f:field(Flag, "stats", translate("Enable monitoring"))
 enableStats.default = 0 -- this does not work
 function enableStats.cfgvalue(self, section)
   return tostring(uci:get("ffwizard", "settings" , "enableStats")) or "0"

--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua
@@ -13,14 +13,14 @@ css.template = "freifunk/assistent/snippets/css"
 shareBandwidth = f:field(DummyValue, "shareBandwidthfo", "")
 shareBandwidth.template = "freifunk/assistent/snippets/shareBandwidth"
 
-local usersBandwidthDown = f:field(Value, "usersBandwidthDown", translate("Download-Bandbreite in Mbit/s"))
+local usersBandwidthDown = f:field(Value, "usersBandwidthDown", translate("Download bandwidth in Mbit/s"))
 usersBandwidthDown.datatype = "float"
 usersBandwidthDown.rmempty = false
 function usersBandwidthDown.cfgvalue(self, section)
   return uci:get("ffwizard", "settings", "usersBandwidthDown")
 end
 
-local usersBandwidthUp = f:field(Value, "usersBandwidthUp", translate("Upload-Bandbreite in Mbit/s"))
+local usersBandwidthUp = f:field(Value, "usersBandwidthUp", translate("Upload bandwidth in Mbit/s"))
 usersBandwidthUp.datatype = "float"
 usersBandwidthUp.rmempty = false
 function usersBandwidthUp.cfgvalue(self, section)

--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -45,7 +45,7 @@ uci:foreach("wireless", "wifi-device",
     end
     f:field(DummyValue, device:upper(), devicename)
     wifi_tbl[device] = {}
-    local meship = f:field(Value, "meship_" .. device, translate("Mesh-IP"), "")
+    local meship = f:field(Value, "meship_" .. device, translate("Mesh IP"), "")
     meship.rmempty = false
     meship.datatype = "ip4addr"
     function meship.cfgvalue(self, section)
@@ -65,7 +65,7 @@ uci:foreach("wireless", "wifi-device",
       meshmode.default = "80211s"
     end
     if supportedModes["adhoc"] == true then
-      meshmode:value("adhoc", translate("Ad-Hoc (veraltet)"))
+      meshmode:value("adhoc", translate("Ad-Hoc (outdated)"))
       if supportedModes["80211s"] ~= true then
         meshmode.default = "adhoc"
       end
@@ -83,14 +83,14 @@ if vap == "1" then
   ipinfo = f:field(DummyValue, "ipinfo", "")
   ipinfo.template = "freifunk/assistent/snippets/ipinfo"
 
-  ssid = f:field(Value, "ssid", translate("Freifunk-SSID"), "")
+  ssid = f:field(Value, "ssid", translate("Freifunk SSID"), "")
   ssid.rmempty = false
   function ssid.cfgvalue(self, section)
     return uci:get("ffwizard", "settings", "ssid")
       or uci:get(community, "profile", "ssid")
   end
 
-  dhcpmesh = f:field(Value, "dhcpmesh", translate("DHCP-Network"), "")
+  dhcpmesh = f:field(Value, "dhcpmesh", translate("DHCP Network"), "")
   dhcpmesh.rmempty = false
   dhcpmesh.datatype = "ip4addr"
   function dhcpmesh.cfgvalue(self, section)

--- a/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm
+++ b/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm
@@ -7,25 +7,22 @@
 
   <div class="info alert-message">
     <p class="success">
-<%= translate("Als naechstes kommen die Einstellungen für das Freifunk-Netzwerk. \
-Halte die IPs bereit, die du ueber den Wizard von config.berlin.freifunk.net \
-bekommen hast.") %>
+<%= translate("Next we set the options for the Freifunk network. \
+Have the IPs ready that you received from the config.berlin.freifunk.net wizard") %>
     </p>
   </div>
 
   <div class="tile">
     <div style="text-align: center; margin: 10px">
       <a class="cbi-button cbi-button-save" href="<%=luci.dispatcher.build_url("admin/freifunk/assistent/optionalConfigs")%>?sharenet=0">
-        <%= translate("Am Freifunk-Netz teilnehmen") %>
+        <%= translate("Participate in the Freifunk-Network") %>
       </a>
     </div>
     <div class="alert-message">
       <p class="info">
-        <%= translate("Erweitere das Freifunk-Netz. Du benoetigst dazu eine \
-        WLAN-Verbindung zu einem anderen Freifunk-Router. \
-        Du kannst auf der Freifunk-Karte \
-        nachschauen, wer in deiner Naehe ist, und sie kontaktieren, \
-        damit ihr die Verbindung optimal ausrichten koennt.") %>
+        <%= translate("Expand the Freifunk-Network. You need a WiFi-connection to another \
+        Freifunk router for that. You can check whom is in your neighbourhood on the Freifunk map. \
+        Then you can contact them, to adjust the mesh connection to optimum.") %>
       </p>
     </div>
   </div>
@@ -33,13 +30,13 @@ bekommen hast.") %>
   <div class="tile">
     <div style="text-align: center; margin: 10px">
       <a class="cbi-button cbi-button-save" href="<%=luci.dispatcher.build_url("/admin/freifunk/assistent/sharedInternet")%>">
-        <%= translate("Am Freifunk-Netz teilnehmen und Internet teilen") %>
+        <%= translate("Participate in the Freifunk-Network and share Internet") %>
       </a>
     </div>
     <div class="alert-message">
       <p class="info">
-        <%= translate("Unterstütze die Community, indem du dein Internet im Freifunk-Netzwerk freigibst. \
-        Diese Option ist sowohl mit als auch ohne Verbindung zu anderen Freifunk-Routern sinnvoll.") %>
+        <%= translate("Support the community by sharing your internet to the Freifunk-Network. \
+        This option is sensible in any context, whether you are connected to other Freifunk-Nodes or not.") %>
       </p>
     </div>
   </div>

--- a/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm
+++ b/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm
@@ -8,20 +8,16 @@
 <div class="section">
   <div class="info alert-message">
     <p class="success">
-      <%= translate("Du hast alle Einstellungen geschafft. Dein Router wird jetzt neu gestartet. \
-      Am besten, du machst dir kurz einen Kaffee oder einen Tee :D \
-      und sobald alle Lichter wieder blinken, bist du Freifunkerin!") %>
+      <%= translate("Done! You made all the necessary configuration. Your router will reboot now. \
+      Consider drinking a cup of tea or coffee. :D Once all lights blink again, you will be a Freifunkeer!") %>
     </p>
     <p>
-      <%= translate("Bitte beachte, dass der Router dann unter seiner neuen Freifunk-IP zu \
-      erreichen ist. Von direkt per WLAN oder LAN angeschlossenen Rechnern \
-      ist er auch unter dem Namen <em>frei.funk</em> \
-      zu erreichen.") %>
+      <%= translate("Please mind, that the router router will be reachable by its new Freifunk-IP-address. \
+      From devices connected by WiFi or Ethernet you could use <em>frei.funk</em> also.") %>
     </p>
     <p>
-      <%= translate("Es gibt auch Services im Freifunk-Netz. Ein Liste kannst du dir \
-      im Freifunk-Hauptmenu unter <em>Services</em> ansehen, \
-      sobald dein Router neugestartet hat.") %>
+      <%= translate("There are even exclusive services in Freifunk-Network. You can get a list of them in \
+      the Freifunk-main menu under <em>Services</em>, once your router restarted.") %>
     </p>
   </div>
 </div>

--- a/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/enableStats.htm
+++ b/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/enableStats.htm
@@ -1,7 +1,12 @@
 <div class="alert-message">
   <p class="info">
-    <%= translate("Wenn Du hier den Haken setzt, werden statistische Daten (RAM-Auslastung, CPU-Auslastung, Bandbreitennutzung etc.) dieses Routers erhoben und in der Oberflaeche des Routers angezeigt sowie an monitor.berlin.freifunk.net geschickt. \
-    Es werden keine Statistiken erhoben, wenn du den Haken nicht setzt. Du kannst die Statistiken spaeter ueber Administration &gt; Statistics &gt; Collectd einschalten. \
-    Auf Routern mit nur 4MB ROM steht das Monitoring nicht zur Verfuegung. Auf Routern mit nur 32MB RAM werden die Daten nur auf monitor.berlin.freifunk.net dargestellt, nicht lokal in der Router-Oberflaeche.") %>
+    <%= translate("By enabling this option, the router shows statistic data \
+    (like memory-usage, CPU-usage, bandwidth-use, etc) in the user interface \
+    and sends them to monitor.berlin.freifunk.net. The router won't log statistic \
+    data, if you don't check the box. Under <em>Administration &gt; Statistics &gt; Collectd</em> \
+    you can activate the statistics afterwards. On routers with only 4MiB of flash, \
+    monitoring is not available. On routers with only 32MiB of memory, statistics \
+    data will be only send to monitor.berlin.freifunk.net, but not displayed in the \
+    local user interface.") %>
   </p>
 </div>

--- a/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/generalInfo.htm
+++ b/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/generalInfo.htm
@@ -1,16 +1,10 @@
 <div class="alert-message">
   <p class="info">
-    <%= translate("Wenn du möchtest, kannst du hier deine Kontaktdaten eingeben. \
-    Die Kontaktdaten werden auf der Infoseite des Routers sowie auf \
-    der Freifunk-Karte \
-    angezeigt. So koennen dich andere Freifunkerinnen finden und \
-    dich ansprechen, falls sie Ihren Router mit deinem verbinden \
-    moechten. \
-    <br/>Falls du hier nichts angeben möchtest, kannst du den \
-    Punkt auch einfach ueberspringen oder einzelne Felder leerlassen. \
-    <br/>Den (eindeutigen) Namen dieses Freifunk-Knotens musst du \
-    allerdings setzen. \
-    <br/>Du kannst diese Daten auch später noch ändern, indem du nur \
-    diese Seite des Assistenten benutzt.") %>
+    <%= translate("If you like, you can paste your contact details here. Those get displayed on \
+    the routers info page and the Freifunk map. This way, other Freifunk peers can contact you \
+    if they would like to make a mesh-connection to you. If you don't like to give that information, \
+    you could simply skip that page or leave some forms empty. But you must set the (unique) Name \
+    of this Freifunk-node. You can update this data later on by using the contact page in the routers \
+    web interface at <em>Freifunk &gt; Contact</em>.") %>
   </p>
 </div>

--- a/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/ipinfo.htm
+++ b/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/ipinfo.htm
@@ -1,19 +1,13 @@
 <div class="alert-message">
   <p>
-    <%= translate("Die SSID des Freifunk-WLAN-APs solltest du auf <em>berlin.freifunk.net</em> lassen, \
-    sofern sich nicht in unmittelbarer Naehe ein weiterer Access Point \
-    mit der gleichen SSID befindet. Auf diese Weise koennen sich \
-    Gaeste z.B. mit ihrem Smartphone in der ganzen Gegend mit dem \
-    Freifunk-Netzwerk verbinden, ohne spezielle Einstellungen fuer \
-    jeden einzelnen Router vornehmen zu muessen. \
-    <br/>Diese Einstellung bezieht sich auf den WLAN-AP, <em>nicht</em> das Adhoc-Netzwerk, \
-    das fuer das Freifunk-Meshing benutzt wird.") %>
+    <%= translate("You should leave the SSID at <em>berlin.freifunk.net</em>, as long as there is \
+    not an access point with the same SSID nearby. Thus, people can connect to the Freifunk network \
+    in the whole area, without having to connect to every node individually. <br/>This option \
+    influences the WiFi-AP, <em>not</em> the mesh-network for the mesh connections.") %>
   </p>
   <p class="info">
-    <%= translate("Die DHCP-Einstellung regelt die Vergabe von IP-Adressen an Clients deines \
-    Freifunk-Netzwerkes. \
-    Die noetige Angabe solltest du von \
-    config.berlin.freifunk.net bekommen haben. \
-    Dabei wird die CIDR-Schreibweise benutzt (Beispiel: 10.42.42.42/28).") %>
+    <%= translate("The DHCP-options controls the distribution of IP-addresses to the clients of your \
+    Freifunk-WiFi. You should have gotten the addresses from <em>config.berlin.freifunk.net</em>. We \
+    use the CIDR-notation (i.e. 10.42.42.42/28).") %>
   </p>
 </div>

--- a/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/meshipinfo.htm
+++ b/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/meshipinfo.htm
@@ -1,10 +1,8 @@
 <div class="alert-message">
   <p class="info">
-    <%= translate("Im Folgenden werden die IPs eingetragen, die du vom Wizard unter \
-    config.berlin.freifunk.net \
-    bekommen hast. \
-    Ueber diese Adresse(n) verbindet sich dein Router mit anderen Freifunk-Routern \
-    in deiner Naehe. Spaeter kannst du dir die Einstellungen unter <em>Network \
-    &gt; Interfaces und Network &gt; Wireless</em> anschauen.") %>
+    <%= translate("Next, we enter the IP-addresses that we got from \
+    <em>config.berlin.freifunk.net</em>. With this addresses, your router connects to other \
+    Freifunk routers in range. You can display them at <em>Network &gt; Interfaces and \
+    Network &gt; Wireless</em> later on.") %>
   </p>
 </div>

--- a/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/shareBandwidth.htm
+++ b/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/shareBandwidth.htm
@@ -1,10 +1,11 @@
 <div class="alert-message">
   <p class="info">
-    <%= translate("Die Knoten des Freifunk-Netzes leiten die Daten auf der Basis des kuerzesten Wegs und der hoechsten Bandbreite weiter. \
-    Dazu muss bekannt sein, wieviel Bandbreite ins Internet du auf deinem Knoten zur Verfuegung stellen kannst und willst. \
-    Typische Gesamtbandbreiten sind z.B. bei <em>DSL 6000</em> 6.0 Mbit/s Download und 0.5 Mbit/s Upload oder bei <em>VDSL 50000</em> 50.0 Mbit/s Download und 10.0 Mbit/s Upload. \
-    Am besten testest du z.B. unter speedof.me mehrmals, wieviel Bandbreite dir tatsaechlich zur Verfuegung steht. \
-    Dann gib hier an, wieviel du mit deinen Nachbarn teilen moechtest. \
-    Sei grosszuegig, aber nicht ueberbieten. :-)") %>
+    <%= translate("The nodes of the Freifunk network forward data based on shortest paths and highest \
+    bandwidth. Therefore we need to know, how much bandwidth to the internet there is and how much do \
+    you want to share. Typical values are 6.0 Mbit/s download and 0.5 Mbit/s upload with \
+    <em>DSL 6000</em> or 50.0 Mbit/s download and 10.0 Mbit/s upload with <em>VDSL 50000</em>. \
+    Preferably you test the actual bandwidth multiple times with a tool like <em>speedof.me</em>. Then \
+    you can fill in how much bandwidth you are willing to share with your peers. Please be generous, \
+    but don't overestimate. :-)") %>
   </p>
 </div>

--- a/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/vpncertreupload.htm
+++ b/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/vpncertreupload.htm
@@ -1,5 +1,5 @@
 <div style="text-align: center; margin: 10px">
   <a class="cbi-button cbi-button-save" href="<%=luci.dispatcher.build_url("admin/freifunk/assistent/sharedInternet")%>?reupload=1">
-    <%= translate("Schluessel loeschen und erneut hochladen") %>
+    <%= translate("Delete key and upload again") %>
   </a>
 </div>

--- a/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/vpninfo.htm
+++ b/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/vpninfo.htm
@@ -1,7 +1,5 @@
 <div class="alert-message">
   <p class="info">
-    <%= translate("Im Folgenden wird dein Schluessel zum Tunnel/VPN gebraucht. \
-    Du entpackst die Datei, die dir zugeschickt wurde, und lädst hier dein Zertifikat \
-    und deinen Schlüssel hoch.") %>
+    <%= translate("Now we need the key for the tunnel/VPN. Please unzip the file you got by email and upload the certificate and the key here.") %>
   </p>
 </div>

--- a/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/welcome.htm
+++ b/luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/welcome.htm
@@ -1,12 +1,10 @@
 <div class="info alert-message">
   <p class="success">
-    <%= translate("Herzlichen Glueckwunsch! \
-    <br/>Du hast deinen Router erfolgreich mit der Freifunk-Firmware ausgestattet. \
-    Dieser Assistent hilft dir beim Einrichten deines Routers. Wenn du keine Hilfe \
-    brauchst, kannst du in der Administrationsoberfläche \
-    die Einstellungen auch alleine vornehmen. \
-    <br/>Aendere hier zunaechst dein Password. Bitte waehle ein \
-    sicheres Passwort, da der Router nach aussen sichtbar ist. \
-    Spaeter findest du diese Option im Bereich <em>System &gt; Administration.</em>") %>
+    <%= translate("Congratulations! <br/>You've installed the Freifunk firmware successfully on \
+    your device. This assistant helps you with the configuration. If you don't need help with that, \
+    you can safely skip this, go to the admin interface and do the configuration on your own. \
+    <br/>Beforehand, change your password please. Please use a strong password, because the \
+    router is visible to the Freifunk network. Later on, you will find this option at \
+    <em>System &gt; Administration.</em>") %>
   </p>
 </div>

--- a/luci/luci-app-ffwizard-falter/po/de/ffwizard-falter.po
+++ b/luci/luci-app-ffwizard-falter/po/de/ffwizard-falter.po
@@ -1,15 +1,15 @@
 msgid ""
 msgstr ""
-"Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: luci-app-ffwizard-falter\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
 "Last-Translator: Martin Hübner <martin.hubner@web.de>\n"
 "Language-Team: Martin\n"
-"MIME-Version: 1.0\n"
-"Content-Transfer-Encoding: 8bit\n"
 "Language: de\n"
-"X-Generator: Poedit 3.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.2.2\n"
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:42
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:25
@@ -43,49 +43,39 @@ msgstr "Greife ohne Login auf Statusdaten zu"
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:68
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:54
 msgid "Ad-Hoc (outdated)"
 msgstr "Ad-Hoc (veraltet)"
 
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:68
-msgid "Ad-Hoc (veraltet)"
-msgstr "Ad-Hoc (veraltet)"
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:10
-msgid ""
-"Als naechstes kommen die Einstellungen für das Freifunk-Netzwerk. Halte die "
-"IPs bereit, die du ueber den Wizard von config.berlin.freifunk.net bekommen "
-"hast."
-msgstr ""
-"Als nächstes kommen die Einstellungen für das Freifunk-Netzwerk. Halte die "
-"IPs bereit, die du über den Wizard von config.berlin.freifunk.net bekommen "
-"hast."
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:19
-msgid "Am Freifunk-Netz teilnehmen"
-msgstr "Am Freifunk-Netz teilnehmen"
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:36
-msgid "Am Freifunk-Netz teilnehmen und Internet teilen"
-msgstr "Am Freifunk-Netz teilnehmen und Internet teilen"
-
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/optionalConfigs.lua:17
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:25
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:50
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:47
 msgid "Back"
 msgstr "Zurück"
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm:16
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/enableStats.htm:3
 msgid ""
-"Bitte beachte, dass der Router dann unter seiner neuen Freifunk-IP zu "
-"erreichen ist. Von direkt per WLAN oder LAN angeschlossenen Rechnern ist er "
-"auch unter dem Namen <em>frei.funk</em> zu erreichen."
+"By enabling this option, the router shows statistic data (like memory-usage, "
+"CPU-usage, bandwidth-use, etc) in the user interface and sends them to "
+"monitor.berlin.freifunk.net. The router won't log statistic data, if you "
+"don't check the box. Under <em>Administration &gt; Statistics &gt; Collectd</"
+"em> you can activate the statistics afterwards. On routers with only 4MiB of "
+"flash, monitoring is not available. On routers with only 32MiB of memory, "
+"statistics data will be only send to monitor.berlin.freifunk.net, but not "
+"displayed in the local user interface."
 msgstr ""
-"Bitte beachte, dass der Router dann unter seiner neuen Freifunk-IP zu "
-"erreichen ist. Von direkt per WLAN oder LAN angeschlossenen Rechnern ist er "
-"auch unter dem Namen <em>frei.funk</em> zu erreichen."
+"Wenn Du hier den Haken setzt, werden statistische Daten (RAM-Auslastung, CPU-"
+"Auslastung, Bandbreitennutzung etc.) dieses Routers erhoben und in der "
+"Oberfläche des Routers angezeigt sowie an monitor.berlin.freifunk.net "
+"geschickt. Es werden keine Statistiken erhoben, wenn du den Haken nicht "
+"setzt. Du kannst die Statistiken später über Administration &gt; Statistiken "
+"&gt; Collectd einschalten. Auf Routern mit nur 4MB Flash steht das "
+"Monitoring nicht zur Verfügung. Auf Routern mit nur 32MB RAM werden die "
+"Daten nur auf monitor.berlin.freifunk.net dargestellt, nicht lokal in der "
+"Router-Oberfläche."
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:51
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:48
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -93,24 +83,215 @@ msgstr "Abbrechen"
 msgid "Confirmation"
 msgstr "Bestätigen"
 
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:93
-msgid "DHCP-Network"
-msgstr "DHCP-Netz"
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:33
-msgid "Dein Nickname"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:39
-msgid "Dein Realname"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/ipinfo.htm:13
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/welcome.htm:3
 msgid ""
-"Die DHCP-Einstellung regelt die Vergabe von IP-Adressen an Clients deines "
-"Freifunk-Netzwerkes. Die noetige Angabe solltest du von config.berlin."
-"freifunk.net bekommen haben. Dabei wird die CIDR-Schreibweise benutzt "
-"(Beispiel: 10.42.42.42/28)."
+"Congratulations! <br/>You've installed the Freifunk firmware successfully on "
+"your device. This assistant helps you with the configuration. If you don't "
+"need help with that, you can safely skip this, go to the admin interface and "
+"do the configuration on your own. <br/>Beforehand, change your password "
+"please. Please use a strong password, because the router is visible to the "
+"Freifunk network. Later on, you will find this option at <em>System &gt; "
+"Administration.</em>"
+msgstr ""
+"Herzlichen Glückwunsch! <br/>Du hast deinen Router erfolgreich mit der "
+"Freifunk-Firmware ausgestattet. Dieser Assistent hilft dir beim Einrichten "
+"deines Routers. Wenn du keine Hilfe brauchst, kannst du in der "
+"Administrationsoberfläche die Einstellungen auch alleine vornehmen. <br/"
+">Ändere hier zunächst dein Password. Bitte wähle ein sicheres Passwort, da "
+"der Router nach außen sichtbar ist. Später findest du diese Option im "
+"Bereich <em>System &gt; Administration.</em>"
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:93
+msgid "DHCP Network"
+msgstr "DHCP-Netzwerk"
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/vpncertreupload.htm:3
+msgid "Delete key and upload again"
+msgstr "Schlüssel löschen und erneut hochladen"
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm:11
+msgid ""
+"Done! You made all the necessary configuration. Your router will reboot now. "
+"Consider drinking a cup of tea or coffee. :D Once all lights blink again, "
+"you will be a Freifunkeer!"
+msgstr ""
+"Du hast alle Einstellungen geschafft. Dein Router wird jetzt neu gestartet. "
+"Am besten, du machst dir kurz einen Kaffee oder einen Tee :D und sobald alle "
+"Lichter wieder blinken, bist du Freifunkerin!"
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua:16
+msgid "Download bandwidth in Mbit/s"
+msgstr "Download-Bandbreite in Mbit/s"
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:45
+msgid "E-Mail"
+msgstr "E-Mail"
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/optionalConfigs.lua:26
+msgid "Enable monitoring"
+msgstr "Monitoring anschalten"
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:23
+msgid ""
+"Expand the Freifunk-Network. You need a WiFi-connection to another Freifunk "
+"router for that. You can check whom is in your neighbourhood on the Freifunk "
+"map. Then you can contact them, to adjust the mesh connection to optimum."
+msgstr ""
+"Erweitere das Freifunk-Netz. Du benötigst dazu eine WLAN-Verbindung zu einem "
+"anderen Freifunk-Router. Du kannst auf der Freifunk-Karte nachschauen, wer "
+"in deiner Nähe ist, und sie kontaktieren, damit ihr die Verbindung optimal "
+"ausrichten könnt."
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:86
+msgid "Freifunk SSID"
+msgstr "Freifunk SSID"
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:16
+msgid "Freifunk-Community"
+msgstr "Freifunk-Community"
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:69
+msgid "Height above the ground"
+msgstr "Höhe über Grund"
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/generalInfo.htm:3
+msgid ""
+"If you like, you can paste your contact details here. Those get displayed on "
+"the routers info page and the Freifunk map. This way, other Freifunk peers "
+"can contact you if they would like to make a mesh-connection to you. If you "
+"don't like to give that information, you could simply skip that page or "
+"leave some forms empty. But you must set the (unique) Name of this Freifunk-"
+"node. You can update this data later on by using the contact page in the "
+"routers web interface at <em>Freifunk &gt; Contact</em>."
+msgstr ""
+"Wenn du möchtest, kannst du hier deine Kontaktdaten eingeben. Die "
+"Kontaktdaten werden auf der Infoseite des Routers sowie auf der Freifunk-"
+"Karte angezeigt. So koennen dich andere Freifunkerinnen finden und dich "
+"ansprechen, falls sie Ihren Router mit deinem verbinden moechten. <br/>Falls "
+"du hier nichts angeben möchtest, kannst du den Punkt auch einfach "
+"ueberspringen oder einzelne Felder leerlassen. <br/>Den (eindeutigen) Namen "
+"dieses Freifunk-Knotens musst du allerdings setzen. <br/>Du kannst diese "
+"Daten auch später noch ändern, indem du in der Weboberfläche des Routers die "
+"Kontaktseite aufrufst: <em>Freifunk &gt; Kontakt</em>."
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:57
+msgid "Latitude"
+msgstr "Geographischer Breitengrad"
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua:42
+msgid "Local Certificate"
+msgstr "Lokales Zertifikat"
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua:47
+msgid "Local Key"
+msgstr "Lokaler Schlüssel"
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:51
+msgid "Location"
+msgstr "Standort"
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:63
+msgid "Longitude"
+msgstr "Geographischer Längengrad"
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:48
+msgid "Mesh IP"
+msgstr "Mesh-IP"
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:61
+msgid "Mesh Mode"
+msgstr "Mesh-Modus"
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:27
+msgid "Name of this Freifunk node"
+msgstr "Name dieses Freifunk-Knotens"
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/changePassword.lua:5
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:7
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/optionalConfigs.lua:16
+msgid "Next"
+msgstr "Weiter"
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:10
+msgid ""
+"Next we set the options for the Freifunk network. Have the IPs ready that "
+"you received from the config.berlin.freifunk.net wizard"
+msgstr ""
+"Als nächstes kommen die Einstellungen für das Freifunk-Netzwerk. Halte die "
+"IPs bereit, die du über den Wizard von config.berlin.freifunk.net bekommen "
+"hast"
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/meshipinfo.htm:3
+msgid ""
+"Next, we enter the IP-addresses that we got from <em>config.berlin.freifunk."
+"net</em>. With this addresses, your router connects to other Freifunk "
+"routers in range. You can display them at <em>Network &gt; Interfaces and "
+"Network &gt; Wireless</em> later on."
+msgstr ""
+"Im Folgenden werden die IPs eingetragen, die du vom Wizard unter config."
+"berlin.freifunk.net bekommen hast. Über diese Adresse(n) verbindet sich dein "
+"Router mit anderen Freifunk-Routern in deiner Nähe. Später kannst du dir die "
+"Einstellungen unter <em>Netzwerk &gt; Schnittstellen und Netzwerk &gt; "
+"Drahtlos</em> anschauen."
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/vpninfo.htm:3
+msgid ""
+"Now we need the key for the tunnel/VPN. Please unzip the file you got by "
+"email and upload the certificate and the key here."
+msgstr ""
+"Im Folgenden wird dein Schlüssel zum Tunnel/VPN gebraucht. Du entpackst die "
+"Datei, die dir zugeschickt wurde, und lädst hier dein Zertifikat und deinen "
+"Schlüssel hoch."
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:18
+msgid "Participate in the Freifunk-Network"
+msgstr "Am Freifunk-Netz teilnehmen"
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:33
+msgid "Participate in the Freifunk-Network and share Internet"
+msgstr "Am Freifunk-Netz teilnehmen und Internet teilen"
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/changePassword.lua:18
+msgid "Password"
+msgstr "Passwort"
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm:15
+msgid ""
+"Please mind, that the router router will be reachable by its new Freifunk-IP-"
+"address. From devices connected by WiFi or Ethernet you could use <em>frei."
+"funk</em> also."
+msgstr ""
+"Bitte beachte, dass der Router dann unter seiner neuen Freifunk-IP zu "
+"erreichen ist. Von direkt per WLAN oder LAN angeschlossenen Rechnern ist er "
+"auch unter dem Namen <em>frei.funk</em> zu erreichen."
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:24
+msgid "Save and reboot"
+msgstr "Speichern und Neustarten"
+
+#: luci/luci-app-ffwizard-falter/root/usr/share/rpcd/acl.d/luci-app-ffwizard-falter.json:3
+msgid "Super user access role"
+msgstr "Super user access role"
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:38
+msgid ""
+"Support the community by sharing your internet to the Freifunk-Network. This "
+"option is sensible in any context, whether you are connected to other "
+"Freifunk-Nodes or not."
+msgstr ""
+"Unterstütze die Community, indem du dein Internet im Freifunk-Netzwerk "
+"freigibst. Diese Option ist sowohl mit als auch ohne Verbindung zu anderen "
+"Freifunk-Routern sinnvoll."
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:42
+msgid "The"
+msgstr "Die"
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/ipinfo.htm:9
+msgid ""
+"The DHCP-options controls the distribution of IP-addresses to the clients of "
+"your Freifunk-WiFi. You should have gotten the addresses from <em>config."
+"berlin.freifunk.net</em>. We use the CIDR-notation (i.e. 10.42.42.42/28)."
 msgstr ""
 "Die DHCP-Einstellung regelt die Vergabe von IP-Adressen an Clients deines "
 "Freifunk-Netzwerkes. Die nötige Angabe solltest du von config.berlin."
@@ -119,15 +300,14 @@ msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/shareBandwidth.htm:3
 msgid ""
-"Die Knoten des Freifunk-Netzes leiten die Daten auf der Basis des kuerzesten "
-"Wegs und der hoechsten Bandbreite weiter. Dazu muss bekannt sein, wieviel "
-"Bandbreite ins Internet du auf deinem Knoten zur Verfuegung stellen kannst "
-"und willst. Typische Gesamtbandbreiten sind z.B. bei <em>DSL 6000</em> 6.0 "
-"Mbit/s Download und 0.5 Mbit/s Upload oder bei <em>VDSL 50000</em> 50.0 Mbit/"
-"s Download und 10.0 Mbit/s Upload. Am besten testest du z.B. unter speedof."
-"me mehrmals, wieviel Bandbreite dir tatsaechlich zur Verfuegung steht. Dann "
-"gib hier an, wieviel du mit deinen Nachbarn teilen moechtest. Sei "
-"grosszuegig, aber nicht ueberbieten. :-)"
+"The nodes of the Freifunk network forward data based on shortest paths and "
+"highest bandwidth. Therefore we need to know, how much bandwidth to the "
+"internet there is and how much do you want to share. Typical values are 6.0 "
+"Mbit/s download and 0.5 Mbit/s upload with <em>DSL 6000</em> or 50.0 Mbit/s "
+"download and 10.0 Mbit/s upload with <em>VDSL 50000</em>. Preferably you "
+"test the actual bandwidth multiple times with a tool like <em>speedof.me</"
+"em>. Then you can fill in how much bandwidth you are willing to share with "
+"your peers. Please be generous, but don't overestimate. :-)"
 msgstr ""
 "Die Knoten des Freifunk-Netzes leiten die Daten auf der Basis des kürzesten "
 "Wegs und der höchsten Bandbreite weiter. Dazu muss bekannt sein, wie viel "
@@ -138,180 +318,6 @@ msgstr ""
 "me mehrmals, wie viel Bandbreite dir tatsächlich zur Verfügung steht. Dann "
 "gib hier an, wie viel du mit deinen Nachbarn teilen möchtest. Sei großzügig, "
 "aber nicht überbieten. :-)"
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/ipinfo.htm:3
-msgid ""
-"Die SSID des Freifunk-WLAN-APs solltest du auf <em>berlin.freifunk.net</em> "
-"lassen, sofern sich nicht in unmittelbarer Naehe ein weiterer Access Point "
-"mit der gleichen SSID befindet. Auf diese Weise koennen sich Gaeste z.B. mit "
-"ihrem Smartphone in der ganzen Gegend mit dem Freifunk-Netzwerk verbinden, "
-"ohne spezielle Einstellungen fuer jeden einzelnen Router vornehmen zu "
-"muessen. <br/>Diese Einstellung bezieht sich auf den WLAN-AP, <em>nicht</em> "
-"das Adhoc-Netzwerk, das fuer das Freifunk-Meshing benutzt wird."
-msgstr ""
-"Die SSID des Freifunk-WLAN-APs solltest du auf <em>berlin.freifunk.net</em> "
-"lassen, sofern sich nicht in unmittelbarer Nähe ein weiterer Access Point "
-"mit der gleichen SSID befindet. Auf diese Weise können sich Gäste z.B. mit "
-"ihrem Smartphone in der ganzen Gegend mit dem Freifunk-Netzwerk verbinden, "
-"ohne spezielle Einstellungen für jeden einzelnen Router vornehmen zu müssen. "
-"<br/>Diese Einstellung bezieht sich auf den WLAN-AP, <em>nicht</em> das "
-"Adhoc-Netzwerk, das für das Freifunk-Meshing benutzt wird."
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua:16
-msgid "Download-Bandbreite in Mbit/s"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm:11
-msgid ""
-"Du hast alle Einstellungen geschafft. Dein Router wird jetzt neu gestartet. "
-"Am besten, du machst dir kurz einen Kaffee oder einen Tee :D und sobald alle "
-"Lichter wieder blinken, bist du Freifunkerin!"
-msgstr ""
-"Du hast alle Einstellungen geschafft. Dein Router wird jetzt neu gestartet. "
-"Am besten, du machst dir kurz einen Kaffee oder einen Tee :D und sobald alle "
-"Lichter wieder blinken, bist du Freifunkerin!"
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:45
-msgid "E-Mail"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:24
-msgid ""
-"Erweitere das Freifunk-Netz. Du benoetigst dazu eine WLAN-Verbindung zu "
-"einem anderen Freifunk-Router. Du kannst auf der Freifunk-Karte nachschauen, "
-"wer in deiner Naehe ist, und sie kontaktieren, damit ihr die Verbindung "
-"optimal ausrichten koennt."
-msgstr ""
-"Erweitere das Freifunk-Netz. Du benötigst dazu eine WLAN-Verbindung zu einem "
-"anderen Freifunk-Router. Du kannst auf der Freifunk-Karte nachschauen, wer "
-"in deiner Nähe ist, und sie kontaktieren, damit ihr die Verbindung optimal "
-"ausrichten könnt."
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm:22
-msgid ""
-"Es gibt auch Services im Freifunk-Netz. Ein Liste kannst du dir im Freifunk-"
-"Hauptmenu unter <em>Services</em> ansehen, sobald dein Router neugestartet "
-"hat."
-msgstr ""
-"Es gibt auch Services im Freifunk-Netz. Ein Liste kannst du dir im Freifunk-"
-"Hauptmenü unter <em>Services</em> ansehen, sobald dein Router neu gestartet "
-"hat."
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:16
-msgid "Freifunk-Community"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:86
-msgid "Freifunk-SSID"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:57
-msgid "Geographischer Breitengrad"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:63
-msgid "Geographischer Längengrad"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/welcome.htm:3
-msgid ""
-"Herzlichen Glueckwunsch! <br/>Du hast deinen Router erfolgreich mit der "
-"Freifunk-Firmware ausgestattet. Dieser Assistent hilft dir beim Einrichten "
-"deines Routers. Wenn du keine Hilfe brauchst, kannst du in der "
-"Administrationsoberfläche die Einstellungen auch alleine vornehmen. <br/"
-">Aendere hier zunaechst dein Password. Bitte waehle ein sicheres Passwort, "
-"da der Router nach aussen sichtbar ist. Spaeter findest du diese Option im "
-"Bereich <em>System &gt; Administration.</em>"
-msgstr ""
-"Herzlichen Glückwunsch! <br/>Du hast deinen Router erfolgreich mit der "
-"Freifunk-Firmware ausgestattet. Dieser Assistent hilft dir beim Einrichten "
-"deines Routers. Wenn du keine Hilfe brauchst, kannst du in der "
-"Administrationsoberfläche die Einstellungen auch alleine vornehmen. <br/"
-">Ändere hier zunächst dein Password. Bitte wähle ein sicheres Passwort, da "
-"der Router nach außen sichtbar ist. Später findest du diese Option im "
-"Bereich <em>System &gt; Administration.</em>"
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:69
-msgid "Höhe über Grund"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/meshipinfo.htm:3
-msgid ""
-"Im Folgenden werden die IPs eingetragen, die du vom Wizard unter config."
-"berlin.freifunk.net bekommen hast. Ueber diese Adresse(n) verbindet sich "
-"dein Router mit anderen Freifunk-Routern in deiner Naehe. Spaeter kannst du "
-"dir die Einstellungen unter <em>Network &gt; Interfaces und Network &gt; "
-"Wireless</em> anschauen."
-msgstr ""
-"Im Folgenden werden die IPs eingetragen, die du vom Wizard unter config."
-"berlin.freifunk.net bekommen hast. Über diese Adresse(n) verbindet sich dein "
-"Router mit anderen Freifunk-Routern in deiner Nähe. Später kannst du dir die "
-"Einstellungen unter <em>Netzwerk &gt; Interfaces und Netzwerk &gt; Drahtlos</"
-"em> anschauen."
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/vpninfo.htm:3
-msgid ""
-"Im Folgenden wird dein Schluessel zum Tunnel/VPN gebraucht. Du entpackst die "
-"Datei, die dir zugeschickt wurde, und lädst hier dein Zertifikat und deinen "
-"Schlüssel hoch."
-msgstr ""
-"Im Folgenden wird dein Schlüssel zum Tunnel/VPN gebraucht. Du entpackst die "
-"Datei, die dir zugeschickt wurde, und lädst hier dein Zertifikat und deinen "
-"Schlüssel hoch."
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua:42
-msgid "Local Certificate"
-msgstr "Lokales Zertifikat"
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua:47
-msgid "Local Key"
-msgstr "Lokaler Schlüssel"
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:61
-msgid "Mesh Mode"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:48
-msgid "Mesh-IP"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/optionalConfigs.lua:26
-msgid "Monitoring anschalten"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:27
-msgid "Name dieses Freifunk-Knotens"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/changePassword.lua:5
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:7
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/optionalConfigs.lua:16
-msgid "Next"
-msgstr "Weiter"
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/changePassword.lua:18
-msgid "Password"
-msgstr "Passwort"
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:24
-msgid "Save and reboot"
-msgstr "Speichern und Neustarten"
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/vpncertreupload.htm:3
-msgid "Schluessel loeschen und erneut hochladen"
-msgstr "Schlüssel löschen und erneut hochladen"
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:51
-msgid "Standort"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/root/usr/share/rpcd/acl.d/luci-app-ffwizard-falter.json:3
-msgid "Super user access role"
-msgstr "Super user access role"
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:42
-msgid "The"
-msgstr "Die"
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:5
 msgid ""
@@ -333,71 +339,315 @@ msgstr ""
 "verwendet werden soll. <em>Du kannst diese Änderungen auch später über die "
 "Seite <strong>Freifunk->WLAN-Mesh-Einstellungen</strong> vornehmen.</em>\""
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:41
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm:19
 msgid ""
-"Unterstütze die Community, indem du dein Internet im Freifunk-Netzwerk "
-"freigibst. Diese Option ist sowohl mit als auch ohne Verbindung zu anderen "
-"Freifunk-Routern sinnvoll."
+"There are even exclusive services in Freifunk-Network. You can get a list of "
+"them in the Freifunk-main menu under <em>Services</em>, once your router "
+"restarted."
 msgstr ""
-"Unterstütze die Community, indem du dein Internet im Freifunk-Netzwerk "
-"freigibst. Diese Option ist sowohl mit als auch ohne Verbindung zu anderen "
-"Freifunk-Routern sinnvoll."
+"Es gibt auch Services im Freifunk-Netz. Ein Liste kannst du dir im Freifunk-"
+"Hauptmenü unter <em>Services</em> ansehen, sobald dein Router neugestartet "
+"hat."
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:4
 msgid "Update Wireless-Mesh Settings"
 msgstr "Aktualisiere WLAN-Mesh Einstellungen"
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua:23
-msgid "Upload-Bandbreite in Mbit/s"
-msgstr ""
+msgid "Upload bandwidth in Mbit/s"
+msgstr "Upload-Bandbreite in Mbit/s"
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/enableStats.htm:3
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/ipinfo.htm:3
 msgid ""
-"Wenn Du hier den Haken setzt, werden statistische Daten (RAM-Auslastung, CPU-"
-"Auslastung, Bandbreitennutzung etc.) dieses Routers erhoben und in der "
-"Oberflaeche des Routers angezeigt sowie an monitor.berlin.freifunk.net "
-"geschickt. Es werden keine Statistiken erhoben, wenn du den Haken nicht "
-"setzt. Du kannst die Statistiken spaeter ueber Administration &gt; "
-"Statistics &gt; Collectd einschalten. Auf Routern mit nur 4MB ROM steht das "
-"Monitoring nicht zur Verfuegung. Auf Routern mit nur 32MB RAM werden die "
-"Daten nur auf monitor.berlin.freifunk.net dargestellt, nicht lokal in der "
-"Router-Oberflaeche."
+"You should leave the SSID at <em>berlin.freifunk.net</em>, as long as there "
+"is not an access point with the same SSID nearby. Thus, people can connect "
+"to the Freifunk network in the whole area, without having to connect to "
+"every node individually. <br/>This option influences the WiFi-AP, <em>not</"
+"em> the mesh-network for the mesh connections."
 msgstr ""
-"Wenn Du hier den Haken setzt, werden statistische Daten (RAM-Auslastung, CPU-"
-"Auslastung, Bandbreitennutzung etc.) dieses Routers erhoben und in der "
-"Oberfläche des Routers angezeigt sowie an monitor.berlin.freifunk.net "
-"geschickt. Es werden keine Statistiken erhoben, wenn du den Haken nicht "
-"setzt. Du kannst die Statistiken später über Administration &gt; Statistiken "
-"&gt; Collectd einschalten. Auf Routern mit nur 4MB ROM steht das Anzeigen "
-"von Statistiken nicht zur Verfügung. Auf Routern mit nur 32MB RAM werden die "
-"Daten nur auf monitor.berlin.freifunk.net dargestellt, nicht lokal in der "
-"Router-Oberfläche."
+"Die SSID des Freifunk-WLAN-APs solltest du auf <em>berlin.freifunk.net</em> "
+"lassen, sofern sich nicht in unmittelbarer Nähe ein weiterer Access Point "
+"mit der gleichen SSID befindet. Auf diese Weise können sich Gäste z.B. mit "
+"ihrem Smartphone in der ganzen Gegend mit dem Freifunk-Netzwerk verbinden, "
+"ohne spezielle Einstellungen für jeden einzelnen Router vornehmen zu müssen. "
+"<br/>Diese Einstellung bezieht sich auf den WLAN-AP, <em>nicht</em> das "
+"Adhoc-Netzwerk, das für das Freifunk-Meshing benutzt wird."
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/generalInfo.htm:3
-msgid ""
-"Wenn du möchtest, kannst du hier deine Kontaktdaten eingeben. Die "
-"Kontaktdaten werden auf der Infoseite des Routers sowie auf der Freifunk-"
-"Karte angezeigt. So koennen dich andere Freifunkerinnen finden und dich "
-"ansprechen, falls sie Ihren Router mit deinem verbinden moechten. <br/>Falls "
-"du hier nichts angeben möchtest, kannst du den Punkt auch einfach "
-"ueberspringen oder einzelne Felder leerlassen. <br/>Den (eindeutigen) Namen "
-"dieses Freifunk-Knotens musst du allerdings setzen. <br/>Du kannst diese "
-"Daten auch später noch ändern, indem du nur diese Seite des Assistenten "
-"benutzt."
-msgstr ""
-"Wenn du möchtest, kannst du hier deine Kontaktdaten eingeben. Die "
-"Kontaktdaten werden auf der Infoseite des Routers sowie auf der Freifunk-"
-"Karte angezeigt. So können dich andere Freifunkerinnen finden und dich "
-"ansprechen, falls sie Ihren Router mit deinem verbinden möchten. <br/>Falls "
-"du hier nichts angeben möchtest, kannst du den Punkt auch einfach "
-"überspringen oder einzelne Felder leer lassen. <br/>Den (eindeutigen) Namen "
-"dieses Freifunk-Knotens musst du allerdings setzen. <br/>Du kannst diese "
-"Daten auch später noch ändern, indem du nur diese Seite des Assistenten "
-"benutzt."
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:33
+msgid "Your Nickname"
+msgstr "Dein Nickname"
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:39
+msgid "Your Realname"
+msgstr "Dein Realname"
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:43
 msgid "device is currently set to <strong>"
 msgstr "Das Gerät nutzt aktuell <strong>"
+
+#~ msgid ""
+#~ "If you like, you can paste your contact details here. Those get displayed "
+#~ "on the routers info page and the Freifunk map. This way, other Freifunk "
+#~ "peers can contact you if they would like to make a mesh-connection to "
+#~ "you. If you don't like to give that information, you could simply skip "
+#~ "that page or leave some forms empty. But you must set the (unique) Name "
+#~ "of this Freifunk-node. You can update this data later on by using only "
+#~ "the first page of this assistant."
+#~ msgstr ""
+#~ "Wenn du möchtest, kannst du hier deine Kontaktdaten eingeben. Die "
+#~ "Kontaktdaten werden auf der Infoseite des Routers sowie auf der Freifunk-"
+#~ "Karte angezeigt. So können dich andere Freifunkerinnen finden und dich "
+#~ "ansprechen, falls sie Ihren Router mit deinem verbinden möchten. <br/"
+#~ ">Falls du hier nichts angeben möchtest, kannst du den Punkt auch einfach "
+#~ "überspringen oder einzelne Felder leer lassen. <br/>Den (eindeutigen) "
+#~ "Namen dieses Freifunk-Knotens musst du allerdings setzen. <br/>Du kannst "
+#~ "diese Daten auch später noch ändern, indem du nur diese Seite des "
+#~ "Assistenten benutzt."
+
+#~ msgid ""
+#~ "Next we set the options for the Freifunk network. Keep the IPs ready that "
+#~ "you got from the config.berlin.freifunk.net wizard."
+#~ msgstr ""
+#~ "Als nächstes kommen die Einstellungen für das Freifunk-Netzwerk. Halte "
+#~ "die IPs bereit, die du über den Wizard von config.berlin.freifunk.net "
+#~ "bekommen hast."
+
+#~ msgid ""
+#~ "Next, we enter the IP-addresses that we got from <em>config.berlin."
+#~ "freifunk.net</em>. With this addresses, your router connects to other "
+#~ "Freifunk routers in range. You can display them at <em>Network &gt; "
+#~ "Interfaces und Network &gt; Wireless</em> later on."
+#~ msgstr ""
+#~ "Im Folgenden werden die IPs eingetragen, die du vom Wizard unter config."
+#~ "berlin.freifunk.net bekommen hast. Über diese Adresse(n) verbindet sich "
+#~ "dein Router mit anderen Freifunk-Routern in deiner Nähe. Später kannst du "
+#~ "dir die Einstellungen unter <em>Netzwerk &gt; Schnittstellen und Netzwerk "
+#~ "&gt; Drahtlos</em> anschauen."
+
+#~ msgid ""
+#~ "The nodes of the Freifunk network foward data based on shortest paths and "
+#~ "highest bandwidth. Therefor we need to know, how much bandwidth to the "
+#~ "internet there is and how much do you want to share. Typical values are "
+#~ "6.0 Mbit/s download and 0.5 Mbit/s upload with <em>DSL 6000</em> or 50.0 "
+#~ "Mbit/s download and 10.0 Mbit/s upload with <em>VDSL 50000</em>. "
+#~ "Preferably you test the actual bandwidth multiple time with a tool like "
+#~ "<em>speedof.me</em>. Then you can fill in how much bandwidth you are "
+#~ "willing to share with your peers. Please be generous, but don't "
+#~ "overestimate. :-)"
+#~ msgstr ""
+#~ "Die Knoten des Freifunk-Netzes leiten die Daten auf der Basis des "
+#~ "kürzesten Wegs und der höchsten Bandbreite weiter. Dazu muss bekannt "
+#~ "sein, wie viel Bandbreite ins Internet du auf deinem Knoten zur Verfügung "
+#~ "stellen kannst und willst. Typische Gesamtbandbreiten sind z.B. bei "
+#~ "<em>DSL 6000</em> 6.0 Mbit/s Download und 0.5 Mbit/s Upload oder bei "
+#~ "<em>VDSL 50000</em> 50.0 Mbit/s Download und 10.0 Mbit/s Upload. Am "
+#~ "besten testest du z.B. unter speedof.me mehrmals, wie viel Bandbreite dir "
+#~ "tatsächlich zur Verfügung steht. Dann gib hier an, wie viel du mit deinen "
+#~ "Nachbarn teilen möchtest. Sei großzügig, aber nicht überbieten. :-)"
+
+#~ msgid "Ad-Hoc (veraltet)"
+#~ msgstr "Ad-Hoc (veraltet)"
+
+#~ msgid ""
+#~ "Als naechstes kommen die Einstellungen für das Freifunk-Netzwerk. Halte "
+#~ "die IPs bereit, die du ueber den Wizard von config.berlin.freifunk.net "
+#~ "bekommen hast."
+#~ msgstr ""
+#~ "Als nächstes kommen die Einstellungen für das Freifunk-Netzwerk. Halte "
+#~ "die IPs bereit, die du über den Wizard von config.berlin.freifunk.net "
+#~ "bekommen hast."
+
+#~ msgid "Am Freifunk-Netz teilnehmen"
+#~ msgstr "Am Freifunk-Netz teilnehmen"
+
+#~ msgid "Am Freifunk-Netz teilnehmen und Internet teilen"
+#~ msgstr "Am Freifunk-Netz teilnehmen und Internet teilen"
+
+#~ msgid ""
+#~ "Bitte beachte, dass der Router dann unter seiner neuen Freifunk-IP zu "
+#~ "erreichen ist. Von direkt per WLAN oder LAN angeschlossenen Rechnern ist "
+#~ "er auch unter dem Namen <em>frei.funk</em> zu erreichen."
+#~ msgstr ""
+#~ "Bitte beachte, dass der Router dann unter seiner neuen Freifunk-IP zu "
+#~ "erreichen ist. Von direkt per WLAN oder LAN angeschlossenen Rechnern ist "
+#~ "er auch unter dem Namen <em>frei.funk</em> zu erreichen."
+
+#~ msgid "DHCP-Network"
+#~ msgstr "DHCP-Netz"
+
+#~ msgid ""
+#~ "Die DHCP-Einstellung regelt die Vergabe von IP-Adressen an Clients deines "
+#~ "Freifunk-Netzwerkes. Die noetige Angabe solltest du von config.berlin."
+#~ "freifunk.net bekommen haben. Dabei wird die CIDR-Schreibweise benutzt "
+#~ "(Beispiel: 10.42.42.42/28)."
+#~ msgstr ""
+#~ "Die DHCP-Einstellung regelt die Vergabe von IP-Adressen an Clients deines "
+#~ "Freifunk-Netzwerkes. Die nötige Angabe solltest du von config.berlin."
+#~ "freifunk.net bekommen haben. Dabei wird die CIDR-Schreibweise benutzt "
+#~ "(Beispiel: 10.42.42.42/28)."
+
+#~ msgid ""
+#~ "Die Knoten des Freifunk-Netzes leiten die Daten auf der Basis des "
+#~ "kuerzesten Wegs und der hoechsten Bandbreite weiter. Dazu muss bekannt "
+#~ "sein, wieviel Bandbreite ins Internet du auf deinem Knoten zur Verfuegung "
+#~ "stellen kannst und willst. Typische Gesamtbandbreiten sind z.B. bei "
+#~ "<em>DSL 6000</em> 6.0 Mbit/s Download und 0.5 Mbit/s Upload oder bei "
+#~ "<em>VDSL 50000</em> 50.0 Mbit/s Download und 10.0 Mbit/s Upload. Am "
+#~ "besten testest du z.B. unter speedof.me mehrmals, wieviel Bandbreite dir "
+#~ "tatsaechlich zur Verfuegung steht. Dann gib hier an, wieviel du mit "
+#~ "deinen Nachbarn teilen moechtest. Sei grosszuegig, aber nicht "
+#~ "ueberbieten. :-)"
+#~ msgstr ""
+#~ "Die Knoten des Freifunk-Netzes leiten die Daten auf der Basis des "
+#~ "kürzesten Wegs und der höchsten Bandbreite weiter. Dazu muss bekannt "
+#~ "sein, wie viel Bandbreite ins Internet du auf deinem Knoten zur Verfügung "
+#~ "stellen kannst und willst. Typische Gesamtbandbreiten sind z.B. bei "
+#~ "<em>DSL 6000</em> 6.0 Mbit/s Download und 0.5 Mbit/s Upload oder bei "
+#~ "<em>VDSL 50000</em> 50.0 Mbit/s Download und 10.0 Mbit/s Upload. Am "
+#~ "besten testest du z.B. unter speedof.me mehrmals, wie viel Bandbreite dir "
+#~ "tatsächlich zur Verfügung steht. Dann gib hier an, wie viel du mit deinen "
+#~ "Nachbarn teilen möchtest. Sei großzügig, aber nicht überbieten. :-)"
+
+#~ msgid ""
+#~ "Die SSID des Freifunk-WLAN-APs solltest du auf <em>berlin.freifunk.net</"
+#~ "em> lassen, sofern sich nicht in unmittelbarer Naehe ein weiterer Access "
+#~ "Point mit der gleichen SSID befindet. Auf diese Weise koennen sich Gaeste "
+#~ "z.B. mit ihrem Smartphone in der ganzen Gegend mit dem Freifunk-Netzwerk "
+#~ "verbinden, ohne spezielle Einstellungen fuer jeden einzelnen Router "
+#~ "vornehmen zu muessen. <br/>Diese Einstellung bezieht sich auf den WLAN-"
+#~ "AP, <em>nicht</em> das Adhoc-Netzwerk, das fuer das Freifunk-Meshing "
+#~ "benutzt wird."
+#~ msgstr ""
+#~ "Die SSID des Freifunk-WLAN-APs solltest du auf <em>berlin.freifunk.net</"
+#~ "em> lassen, sofern sich nicht in unmittelbarer Nähe ein weiterer Access "
+#~ "Point mit der gleichen SSID befindet. Auf diese Weise können sich Gäste z."
+#~ "B. mit ihrem Smartphone in der ganzen Gegend mit dem Freifunk-Netzwerk "
+#~ "verbinden, ohne spezielle Einstellungen für jeden einzelnen Router "
+#~ "vornehmen zu müssen. <br/>Diese Einstellung bezieht sich auf den WLAN-AP, "
+#~ "<em>nicht</em> das Adhoc-Netzwerk, das für das Freifunk-Meshing benutzt "
+#~ "wird."
+
+#~ msgid ""
+#~ "Du hast alle Einstellungen geschafft. Dein Router wird jetzt neu "
+#~ "gestartet. Am besten, du machst dir kurz einen Kaffee oder einen Tee :D "
+#~ "und sobald alle Lichter wieder blinken, bist du Freifunkerin!"
+#~ msgstr ""
+#~ "Du hast alle Einstellungen geschafft. Dein Router wird jetzt neu "
+#~ "gestartet. Am besten, du machst dir kurz einen Kaffee oder einen Tee :D "
+#~ "und sobald alle Lichter wieder blinken, bist du Freifunkerin!"
+
+#~ msgid ""
+#~ "Erweitere das Freifunk-Netz. Du benoetigst dazu eine WLAN-Verbindung zu "
+#~ "einem anderen Freifunk-Router. Du kannst auf der Freifunk-Karte "
+#~ "nachschauen, wer in deiner Naehe ist, und sie kontaktieren, damit ihr die "
+#~ "Verbindung optimal ausrichten koennt."
+#~ msgstr ""
+#~ "Erweitere das Freifunk-Netz. Du benötigst dazu eine WLAN-Verbindung zu "
+#~ "einem anderen Freifunk-Router. Du kannst auf der Freifunk-Karte "
+#~ "nachschauen, wer in deiner Nähe ist, und sie kontaktieren, damit ihr die "
+#~ "Verbindung optimal ausrichten könnt."
+
+#~ msgid ""
+#~ "Es gibt auch Services im Freifunk-Netz. Ein Liste kannst du dir im "
+#~ "Freifunk-Hauptmenu unter <em>Services</em> ansehen, sobald dein Router "
+#~ "neugestartet hat."
+#~ msgstr ""
+#~ "Es gibt auch Services im Freifunk-Netz. Ein Liste kannst du dir im "
+#~ "Freifunk-Hauptmenü unter <em>Services</em> ansehen, sobald dein Router "
+#~ "neu gestartet hat."
+
+#~ msgid ""
+#~ "Herzlichen Glueckwunsch! <br/>Du hast deinen Router erfolgreich mit der "
+#~ "Freifunk-Firmware ausgestattet. Dieser Assistent hilft dir beim "
+#~ "Einrichten deines Routers. Wenn du keine Hilfe brauchst, kannst du in der "
+#~ "Administrationsoberfläche die Einstellungen auch alleine vornehmen. <br/"
+#~ ">Aendere hier zunaechst dein Password. Bitte waehle ein sicheres "
+#~ "Passwort, da der Router nach aussen sichtbar ist. Spaeter findest du "
+#~ "diese Option im Bereich <em>System &gt; Administration.</em>"
+#~ msgstr ""
+#~ "Herzlichen Glückwunsch! <br/>Du hast deinen Router erfolgreich mit der "
+#~ "Freifunk-Firmware ausgestattet. Dieser Assistent hilft dir beim "
+#~ "Einrichten deines Routers. Wenn du keine Hilfe brauchst, kannst du in der "
+#~ "Administrationsoberfläche die Einstellungen auch alleine vornehmen. <br/"
+#~ ">Ändere hier zunächst dein Password. Bitte wähle ein sicheres Passwort, "
+#~ "da der Router nach außen sichtbar ist. Später findest du diese Option im "
+#~ "Bereich <em>System &gt; Administration.</em>"
+
+#~ msgid ""
+#~ "Im Folgenden werden die IPs eingetragen, die du vom Wizard unter config."
+#~ "berlin.freifunk.net bekommen hast. Ueber diese Adresse(n) verbindet sich "
+#~ "dein Router mit anderen Freifunk-Routern in deiner Naehe. Spaeter kannst "
+#~ "du dir die Einstellungen unter <em>Network &gt; Interfaces und Network "
+#~ "&gt; Wireless</em> anschauen."
+#~ msgstr ""
+#~ "Im Folgenden werden die IPs eingetragen, die du vom Wizard unter config."
+#~ "berlin.freifunk.net bekommen hast. Über diese Adresse(n) verbindet sich "
+#~ "dein Router mit anderen Freifunk-Routern in deiner Nähe. Später kannst du "
+#~ "dir die Einstellungen unter <em>Netzwerk &gt; Interfaces und Netzwerk "
+#~ "&gt; Drahtlos</em> anschauen."
+
+#~ msgid ""
+#~ "Im Folgenden wird dein Schluessel zum Tunnel/VPN gebraucht. Du entpackst "
+#~ "die Datei, die dir zugeschickt wurde, und lädst hier dein Zertifikat und "
+#~ "deinen Schlüssel hoch."
+#~ msgstr ""
+#~ "Im Folgenden wird dein Schlüssel zum Tunnel/VPN gebraucht. Du entpackst "
+#~ "die Datei, die dir zugeschickt wurde, und lädst hier dein Zertifikat und "
+#~ "deinen Schlüssel hoch."
+
+#~ msgid "Schluessel loeschen und erneut hochladen"
+#~ msgstr "Schlüssel löschen und erneut hochladen"
+
+#~ msgid ""
+#~ "Unterstütze die Community, indem du dein Internet im Freifunk-Netzwerk "
+#~ "freigibst. Diese Option ist sowohl mit als auch ohne Verbindung zu "
+#~ "anderen Freifunk-Routern sinnvoll."
+#~ msgstr ""
+#~ "Unterstütze die Community, indem du dein Internet im Freifunk-Netzwerk "
+#~ "freigibst. Diese Option ist sowohl mit als auch ohne Verbindung zu "
+#~ "anderen Freifunk-Routern sinnvoll."
+
+#~ msgid ""
+#~ "Wenn Du hier den Haken setzt, werden statistische Daten (RAM-Auslastung, "
+#~ "CPU-Auslastung, Bandbreitennutzung etc.) dieses Routers erhoben und in "
+#~ "der Oberflaeche des Routers angezeigt sowie an monitor.berlin.freifunk."
+#~ "net geschickt. Es werden keine Statistiken erhoben, wenn du den Haken "
+#~ "nicht setzt. Du kannst die Statistiken spaeter ueber Administration &gt; "
+#~ "Statistics &gt; Collectd einschalten. Auf Routern mit nur 4MB ROM steht "
+#~ "das Monitoring nicht zur Verfuegung. Auf Routern mit nur 32MB RAM werden "
+#~ "die Daten nur auf monitor.berlin.freifunk.net dargestellt, nicht lokal in "
+#~ "der Router-Oberflaeche."
+#~ msgstr ""
+#~ "Wenn Du hier den Haken setzt, werden statistische Daten (RAM-Auslastung, "
+#~ "CPU-Auslastung, Bandbreitennutzung etc.) dieses Routers erhoben und in "
+#~ "der Oberfläche des Routers angezeigt sowie an monitor.berlin.freifunk.net "
+#~ "geschickt. Es werden keine Statistiken erhoben, wenn du den Haken nicht "
+#~ "setzt. Du kannst die Statistiken später über Administration &gt; "
+#~ "Statistiken &gt; Collectd einschalten. Auf Routern mit nur 4MB ROM steht "
+#~ "das Anzeigen von Statistiken nicht zur Verfügung. Auf Routern mit nur "
+#~ "32MB RAM werden die Daten nur auf monitor.berlin.freifunk.net "
+#~ "dargestellt, nicht lokal in der Router-Oberfläche."
+
+#~ msgid ""
+#~ "Wenn du möchtest, kannst du hier deine Kontaktdaten eingeben. Die "
+#~ "Kontaktdaten werden auf der Infoseite des Routers sowie auf der Freifunk-"
+#~ "Karte angezeigt. So koennen dich andere Freifunkerinnen finden und dich "
+#~ "ansprechen, falls sie Ihren Router mit deinem verbinden moechten. <br/"
+#~ ">Falls du hier nichts angeben möchtest, kannst du den Punkt auch einfach "
+#~ "ueberspringen oder einzelne Felder leerlassen. <br/>Den (eindeutigen) "
+#~ "Namen dieses Freifunk-Knotens musst du allerdings setzen. <br/>Du kannst "
+#~ "diese Daten auch später noch ändern, indem du nur diese Seite des "
+#~ "Assistenten benutzt."
+#~ msgstr ""
+#~ "Wenn du möchtest, kannst du hier deine Kontaktdaten eingeben. Die "
+#~ "Kontaktdaten werden auf der Infoseite des Routers sowie auf der Freifunk-"
+#~ "Karte angezeigt. So können dich andere Freifunkerinnen finden und dich "
+#~ "ansprechen, falls sie Ihren Router mit deinem verbinden möchten. <br/"
+#~ ">Falls du hier nichts angeben möchtest, kannst du den Punkt auch einfach "
+#~ "überspringen oder einzelne Felder leer lassen. <br/>Den (eindeutigen) "
+#~ "Namen dieses Freifunk-Knotens musst du allerdings setzen. <br/>Du kannst "
+#~ "diese Daten auch später noch ändern, indem du nur diese Seite des "
+#~ "Assistenten benutzt."
 
 #~ msgid ""
 #~ "The wireless interfaces which are built into the router can mesh with "

--- a/luci/luci-app-ffwizard-falter/po/en/ffwizard-falter.po
+++ b/luci/luci-app-ffwizard-falter/po/en/ffwizard-falter.po
@@ -1,15 +1,15 @@
 msgid ""
 msgstr ""
-"Content-Type: text/plain; charset=UTF-8\n"
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
 "Last-Translator: Martin Hübner <martin.hubner@web.de>\n"
 "Language-Team: \n"
-"MIME-Version: 1.0\n"
-"Content-Transfer-Encoding: 8bit\n"
 "Language: en\n"
-"X-Generator: Poedit 3.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.2.2\n"
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:42
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:25
@@ -35,186 +35,45 @@ msgstr ""
 
 #: luci/luci-app-ffwizard-falter/root/usr/share/rpcd/acl.d/ffwizard-berlin.json:3
 msgid "Access some status information without login"
-msgstr "Access some status information without login"
+msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:44
 msgid "Ad-Hoc"
 msgstr ""
 
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:68
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:54
 msgid "Ad-Hoc (outdated)"
-msgstr "Ad-Hoc (outdated)"
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:68
-msgid "Ad-Hoc (veraltet)"
-msgstr "Ad-Hoc (outdated)"
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:10
-msgid ""
-"Als naechstes kommen die Einstellungen für das Freifunk-Netzwerk. Halte die "
-"IPs bereit, die du ueber den Wizard von config.berlin.freifunk.net bekommen "
-"hast."
 msgstr ""
-"Next we set the options for the Freifunk network. Keep the IPs ready that "
-"you got from the config.berlin.freifunk.net wizard."
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:19
-msgid "Am Freifunk-Netz teilnehmen"
-msgstr "Participate in the Freifunk-Network"
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:36
-msgid "Am Freifunk-Netz teilnehmen und Internet teilen"
-msgstr "Participate in the Freifunk-Network and share Internet"
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/optionalConfigs.lua:17
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:25
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:50
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:47
 msgid "Back"
 msgstr ""
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm:16
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/enableStats.htm:3
 msgid ""
-"Bitte beachte, dass der Router dann unter seiner neuen Freifunk-IP zu "
-"erreichen ist. Von direkt per WLAN oder LAN angeschlossenen Rechnern ist er "
-"auch unter dem Namen <em>frei.funk</em> zu erreichen."
+"By enabling this option, the router shows statistic data (like memory-usage, "
+"CPU-usage, bandwidth-use, etc) in the user interface and sends them to "
+"monitor.berlin.freifunk.net. The router won't log statistic data, if you "
+"don't check the box. Under <em>Administration &gt; Statistics &gt; Collectd</"
+"em> you can activate the statistics afterwards. On routers with only 4MiB of "
+"flash, monitoring is not available. On routers with only 32MiB of memory, "
+"statistics data will be only send to monitor.berlin.freifunk.net, but not "
+"displayed in the local user interface."
 msgstr ""
-"Please mind, that the router router will be reachable by its new Freifunk-IP-"
-"address. From devices connected by WiFi or Ethernet you could use <em>frei."
-"funk</em> also."
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:51
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:48
 msgid "Cancel"
 msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/changePassword.lua:24
 msgid "Confirmation"
-msgstr "Confirmation"
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:93
-msgid "DHCP-Network"
 msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:33
-msgid "Dein Nickname"
-msgstr "Your Nickname"
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:39
-msgid "Dein Realname"
-msgstr "Your Realname"
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/ipinfo.htm:13
-msgid ""
-"Die DHCP-Einstellung regelt die Vergabe von IP-Adressen an Clients deines "
-"Freifunk-Netzwerkes. Die noetige Angabe solltest du von config.berlin."
-"freifunk.net bekommen haben. Dabei wird die CIDR-Schreibweise benutzt "
-"(Beispiel: 10.42.42.42/28)."
-msgstr ""
-"The DHCP-options controls the distribution of IP-addresses to the clients of "
-"your Freifunk-WiFi. You should have gotten the addresses from <em>config."
-"berlin.freifunk.net</em>. We use the CIDR-notation (i.e. 10.42.42.42/28)."
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/shareBandwidth.htm:3
-msgid ""
-"Die Knoten des Freifunk-Netzes leiten die Daten auf der Basis des kuerzesten "
-"Wegs und der hoechsten Bandbreite weiter. Dazu muss bekannt sein, wieviel "
-"Bandbreite ins Internet du auf deinem Knoten zur Verfuegung stellen kannst "
-"und willst. Typische Gesamtbandbreiten sind z.B. bei <em>DSL 6000</em> 6.0 "
-"Mbit/s Download und 0.5 Mbit/s Upload oder bei <em>VDSL 50000</em> 50.0 Mbit/"
-"s Download und 10.0 Mbit/s Upload. Am besten testest du z.B. unter speedof."
-"me mehrmals, wieviel Bandbreite dir tatsaechlich zur Verfuegung steht. Dann "
-"gib hier an, wieviel du mit deinen Nachbarn teilen moechtest. Sei "
-"grosszuegig, aber nicht ueberbieten. :-)"
-msgstr ""
-"The nodes of the Freifunk network foward data based on shortest paths and "
-"highest bandwidth. Therefor we need to know, how much bandwidth to the "
-"internet there is and how much do you want to share. Typical values are 6.0 "
-"Mbit/s download and 0.5 Mbit/s upload with <em>DSL 6000</em> or 50.0 Mbit/s "
-"download and 10.0 Mbit/s upload with <em>VDSL 50000</em>. Preferably you "
-"test the actual bandwidth multiple time with a tool like <em>speedof.me</"
-"em>. Then you can fill in how much bandwidth you are willing to share with "
-"your peers. Please be generous, but don't overestimate. :-)"
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/ipinfo.htm:3
-msgid ""
-"Die SSID des Freifunk-WLAN-APs solltest du auf <em>berlin.freifunk.net</em> "
-"lassen, sofern sich nicht in unmittelbarer Naehe ein weiterer Access Point "
-"mit der gleichen SSID befindet. Auf diese Weise koennen sich Gaeste z.B. mit "
-"ihrem Smartphone in der ganzen Gegend mit dem Freifunk-Netzwerk verbinden, "
-"ohne spezielle Einstellungen fuer jeden einzelnen Router vornehmen zu "
-"muessen. <br/>Diese Einstellung bezieht sich auf den WLAN-AP, <em>nicht</em> "
-"das Adhoc-Netzwerk, das fuer das Freifunk-Meshing benutzt wird."
-msgstr ""
-"You should leave the SSID at <em>berlin.freifunk.net</em>, as long as there "
-"is not an access point with the same SSID nearby. Thus, people can connect "
-"to the Freifunk network in the whole area, without having to connect to "
-"every node individually. <br/>This option influences the WiFi-AP, <em>not</"
-"em> the mesh-network for the mesh connections."
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua:16
-msgid "Download-Bandbreite in Mbit/s"
-msgstr "Download bandwidth in Mbit/s"
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm:11
-msgid ""
-"Du hast alle Einstellungen geschafft. Dein Router wird jetzt neu gestartet. "
-"Am besten, du machst dir kurz einen Kaffee oder einen Tee :D und sobald alle "
-"Lichter wieder blinken, bist du Freifunkerin!"
-msgstr ""
-"Done! You made all the necessary configuration. Your router will reboot now. "
-"Consider drinking a cup of tea or coffee. :D Once all lights blink again, "
-"you will be a Freifunkeer!"
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:45
-msgid "E-Mail"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:24
-msgid ""
-"Erweitere das Freifunk-Netz. Du benoetigst dazu eine WLAN-Verbindung zu "
-"einem anderen Freifunk-Router. Du kannst auf der Freifunk-Karte nachschauen, "
-"wer in deiner Naehe ist, und sie kontaktieren, damit ihr die Verbindung "
-"optimal ausrichten koennt."
-msgstr ""
-"Expand the Freifunk-Network. You need a WiFi-connection to another Freifunk "
-"router for that. You can check whom is in your neighbourhood on the Freifunk "
-"map. Then you can contact them, to adjust the mesh connection to optimum."
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm:22
-msgid ""
-"Es gibt auch Services im Freifunk-Netz. Ein Liste kannst du dir im Freifunk-"
-"Hauptmenu unter <em>Services</em> ansehen, sobald dein Router neugestartet "
-"hat."
-msgstr ""
-"There are even exclusive services in Freifunk-Network. You can get a list of "
-"them in the Freifunk-main menu under <em>Services</em>, once your router "
-"restarted."
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:16
-msgid "Freifunk-Community"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:86
-msgid "Freifunk-SSID"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:57
-msgid "Geographischer Breitengrad"
-msgstr "Latitude"
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:63
-msgid "Geographischer Längengrad"
-msgstr "Longitude"
 
 #: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/welcome.htm:3
 msgid ""
-"Herzlichen Glueckwunsch! <br/>Du hast deinen Router erfolgreich mit der "
-"Freifunk-Firmware ausgestattet. Dieser Assistent hilft dir beim Einrichten "
-"deines Routers. Wenn du keine Hilfe brauchst, kannst du in der "
-"Administrationsoberfläche die Einstellungen auch alleine vornehmen. <br/"
-">Aendere hier zunaechst dein Password. Bitte waehle ein sicheres Passwort, "
-"da der Router nach aussen sichtbar ist. Spaeter findest du diese Option im "
-"Bereich <em>System &gt; Administration.</em>"
-msgstr ""
 "Congratulations! <br/>You've installed the Freifunk firmware successfully on "
 "your device. This assistant helps you with the configuration. If you don't "
 "need help with that, you can safely skip this, go to the admin interface and "
@@ -222,56 +81,96 @@ msgstr ""
 "please. Please use a strong password, because the router is visible to the "
 "Freifunk network. Later on, you will find this option at <em>System &gt; "
 "Administration.</em>"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:93
+msgid "DHCP Network"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/vpncertreupload.htm:3
+msgid "Delete key and upload again"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm:11
+msgid ""
+"Done! You made all the necessary configuration. Your router will reboot now. "
+"Consider drinking a cup of tea or coffee. :D Once all lights blink again, "
+"you will be a Freifunkeer!"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua:16
+msgid "Download bandwidth in Mbit/s"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:45
+msgid "E-Mail"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/optionalConfigs.lua:26
+msgid "Enable monitoring"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:23
+msgid ""
+"Expand the Freifunk-Network. You need a WiFi-connection to another Freifunk "
+"router for that. You can check whom is in your neighbourhood on the Freifunk "
+"map. Then you can contact them, to adjust the mesh connection to optimum."
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:86
+msgid "Freifunk SSID"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:16
+msgid "Freifunk-Community"
+msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:69
-msgid "Höhe über Grund"
-msgstr "Height above the ground"
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/meshipinfo.htm:3
-msgid ""
-"Im Folgenden werden die IPs eingetragen, die du vom Wizard unter config."
-"berlin.freifunk.net bekommen hast. Ueber diese Adresse(n) verbindet sich "
-"dein Router mit anderen Freifunk-Routern in deiner Naehe. Spaeter kannst du "
-"dir die Einstellungen unter <em>Network &gt; Interfaces und Network &gt; "
-"Wireless</em> anschauen."
+msgid "Height above the ground"
 msgstr ""
-"Next, we enter the IP-addresses that we got from <em>config.berlin.freifunk."
-"net</em>. With this addresses, your router connects to other Freifunk "
-"routers in range. You can display them at <em>Network &gt; Interfaces und "
-"Network &gt; Wireless</em> later on."
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/vpninfo.htm:3
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/generalInfo.htm:3
 msgid ""
-"Im Folgenden wird dein Schluessel zum Tunnel/VPN gebraucht. Du entpackst die "
-"Datei, die dir zugeschickt wurde, und lädst hier dein Zertifikat und deinen "
-"Schlüssel hoch."
+"If you like, you can paste your contact details here. Those get displayed on "
+"the routers info page and the Freifunk map. This way, other Freifunk peers "
+"can contact you if they would like to make a mesh-connection to you. If you "
+"don't like to give that information, you could simply skip that page or "
+"leave some forms empty. But you must set the (unique) Name of this Freifunk-"
+"node. You can update this data later on by using the contact page in the "
+"routers web interface at <em>Freifunk &gt; Contact</em>."
 msgstr ""
-"Now we need the key for the tunnel/VPN. Please unzip the file you got by "
-"email and upload the certificate and the key here."
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:57
+msgid "Latitude"
+msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua:42
 msgid "Local Certificate"
-msgstr "Local Certificate"
+msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua:47
 msgid "Local Key"
-msgstr "Local Key"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:51
+msgid "Location"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:63
+msgid "Longitude"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:48
+msgid "Mesh IP"
+msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:61
 msgid "Mesh Mode"
 msgstr ""
 
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:48
-msgid "Mesh-IP"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/optionalConfigs.lua:26
-msgid "Monitoring anschalten"
-msgstr "Enable monitoring"
-
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:27
-msgid "Name dieses Freifunk-Knotens"
-msgstr "Name of this Freifunk-node"
+msgid "Name of this Freifunk node"
+msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/changePassword.lua:5
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:7
@@ -279,29 +178,82 @@ msgstr "Name of this Freifunk-node"
 msgid "Next"
 msgstr ""
 
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:10
+msgid ""
+"Next we set the options for the Freifunk network. Have the IPs ready that "
+"you received from the config.berlin.freifunk.net wizard"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/meshipinfo.htm:3
+msgid ""
+"Next, we enter the IP-addresses that we got from <em>config.berlin.freifunk."
+"net</em>. With this addresses, your router connects to other Freifunk "
+"routers in range. You can display them at <em>Network &gt; Interfaces and "
+"Network &gt; Wireless</em> later on."
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/vpninfo.htm:3
+msgid ""
+"Now we need the key for the tunnel/VPN. Please unzip the file you got by "
+"email and upload the certificate and the key here."
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:18
+msgid "Participate in the Freifunk-Network"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:33
+msgid "Participate in the Freifunk-Network and share Internet"
+msgstr ""
+
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/changePassword.lua:18
 msgid "Password"
-msgstr "Password"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm:15
+msgid ""
+"Please mind, that the router router will be reachable by its new Freifunk-IP-"
+"address. From devices connected by WiFi or Ethernet you could use <em>frei."
+"funk</em> also."
+msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:24
 msgid "Save and reboot"
 msgstr ""
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/vpncertreupload.htm:3
-msgid "Schluessel loeschen und erneut hochladen"
-msgstr "Delete key and upload again"
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:51
-msgid "Standort"
-msgstr "Location"
-
 #: luci/luci-app-ffwizard-falter/root/usr/share/rpcd/acl.d/luci-app-ffwizard-falter.json:3
 msgid "Super user access role"
-msgstr "Super user access role"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:38
+msgid ""
+"Support the community by sharing your internet to the Freifunk-Network. This "
+"option is sensible in any context, whether you are connected to other "
+"Freifunk-Nodes or not."
+msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:42
 msgid "The"
-msgstr "The"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/ipinfo.htm:9
+msgid ""
+"The DHCP-options controls the distribution of IP-addresses to the clients of "
+"your Freifunk-WiFi. You should have gotten the addresses from <em>config."
+"berlin.freifunk.net</em>. We use the CIDR-notation (i.e. 10.42.42.42/28)."
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/shareBandwidth.htm:3
+msgid ""
+"The nodes of the Freifunk network forward data based on shortest paths and "
+"highest bandwidth. Therefore we need to know, how much bandwidth to the "
+"internet there is and how much do you want to share. Typical values are 6.0 "
+"Mbit/s download and 0.5 Mbit/s upload with <em>DSL 6000</em> or 50.0 Mbit/s "
+"download and 10.0 Mbit/s upload with <em>VDSL 50000</em>. Preferably you "
+"test the actual bandwidth multiple times with a tool like <em>speedof.me</"
+"em>. Then you can fill in how much bandwidth you are willing to share with "
+"your peers. Please be generous, but don't overestimate. :-)"
+msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:5
 msgid ""
@@ -314,77 +266,264 @@ msgid ""
 "<em>The menu entry <strong>Freifunk->Wireless Mesh</strong> can be visited "
 "at a later time to change these settings.</em>"
 msgstr ""
-"The wireless interfaces which are built into the router can mesh with other "
-"routers using either Ad-Hoc or 802.11s. <strong>802.11s is now the standard "
-"used.</strong> Some routers (or their drivers) might not support this new "
-"standard. Also, if this router currently meshes with Ad-Hoc then changing it "
-"to 802.11s would cause connectivity loss. Please contact your mesh neighbors "
-"to switch to 802.11s collectively. Please select which protocol to use. "
-"<em>The menu entry <strong>Freifunk->Wireless Mesh</strong> can be visited "
-"at a later time to change these settings.</em>"
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:41
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm:19
 msgid ""
-"Unterstütze die Community, indem du dein Internet im Freifunk-Netzwerk "
-"freigibst. Diese Option ist sowohl mit als auch ohne Verbindung zu anderen "
-"Freifunk-Routern sinnvoll."
+"There are even exclusive services in Freifunk-Network. You can get a list of "
+"them in the Freifunk-main menu under <em>Services</em>, once your router "
+"restarted."
 msgstr ""
-"Support the community by sharing your internet to the Freifunk-Network. This "
-"option is sensible in any context, whether you are connected to other "
-"Freifunk-Nodes or not."
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:4
 msgid "Update Wireless-Mesh Settings"
-msgstr "Update Wireless-Mesh Settings"
+msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua:23
-msgid "Upload-Bandbreite in Mbit/s"
-msgstr "Upload bandwidth in Mbit/s"
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/enableStats.htm:3
-msgid ""
-"Wenn Du hier den Haken setzt, werden statistische Daten (RAM-Auslastung, CPU-"
-"Auslastung, Bandbreitennutzung etc.) dieses Routers erhoben und in der "
-"Oberflaeche des Routers angezeigt sowie an monitor.berlin.freifunk.net "
-"geschickt. Es werden keine Statistiken erhoben, wenn du den Haken nicht "
-"setzt. Du kannst die Statistiken spaeter ueber Administration &gt; "
-"Statistics &gt; Collectd einschalten. Auf Routern mit nur 4MB ROM steht das "
-"Monitoring nicht zur Verfuegung. Auf Routern mit nur 32MB RAM werden die "
-"Daten nur auf monitor.berlin.freifunk.net dargestellt, nicht lokal in der "
-"Router-Oberflaeche."
+msgid "Upload bandwidth in Mbit/s"
 msgstr ""
-"By enabling this option, the router shows statistic data (like memory-usage, "
-"CPU-usage, bandwidth-use, etc) in the user interface and sends them to "
-"monitor.berlin.freifunk.net. The router won't log statistic data, if you "
-"don't check the box. Under <em>Administration &gt; Statistics &gt; Collectd</"
-"em> you can activate the statistics afterwards. On routers with only 4MiB of "
-"flash, monitoring is not available. On routers with only 32MiB of memory, "
-"statistics data will be only send to monitor.berlin.freifunk.net, but not "
-"displayed in the local user interface."
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/generalInfo.htm:3
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/ipinfo.htm:3
 msgid ""
-"Wenn du möchtest, kannst du hier deine Kontaktdaten eingeben. Die "
-"Kontaktdaten werden auf der Infoseite des Routers sowie auf der Freifunk-"
-"Karte angezeigt. So koennen dich andere Freifunkerinnen finden und dich "
-"ansprechen, falls sie Ihren Router mit deinem verbinden moechten. <br/>Falls "
-"du hier nichts angeben möchtest, kannst du den Punkt auch einfach "
-"ueberspringen oder einzelne Felder leerlassen. <br/>Den (eindeutigen) Namen "
-"dieses Freifunk-Knotens musst du allerdings setzen. <br/>Du kannst diese "
-"Daten auch später noch ändern, indem du nur diese Seite des Assistenten "
-"benutzt."
+"You should leave the SSID at <em>berlin.freifunk.net</em>, as long as there "
+"is not an access point with the same SSID nearby. Thus, people can connect "
+"to the Freifunk network in the whole area, without having to connect to "
+"every node individually. <br/>This option influences the WiFi-AP, <em>not</"
+"em> the mesh-network for the mesh connections."
 msgstr ""
-"If you like, you can paste your contact details here. Those get displayed on "
-"the routers info page and the Freifunk map. This way, other Freifunk peers "
-"can contact you if they would like to make a mesh-connection to you. If you "
-"don't like to give that information, you could simply skip that page or "
-"leave some forms empty. But you must set the (unique) Name of this Freifunk-"
-"node. You can update this data later on by using only the first page of this "
-"assistant."
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:33
+msgid "Your Nickname"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:39
+msgid "Your Realname"
+msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:43
 msgid "device is currently set to <strong>"
 msgstr ""
+
+#~ msgid "Ad-Hoc (veraltet)"
+#~ msgstr "Ad-Hoc (outdated)"
+
+#~ msgid ""
+#~ "Als naechstes kommen die Einstellungen für das Freifunk-Netzwerk. Halte "
+#~ "die IPs bereit, die du ueber den Wizard von config.berlin.freifunk.net "
+#~ "bekommen hast."
+#~ msgstr ""
+#~ "Next we set the options for the Freifunk network. Keep the IPs ready that "
+#~ "you got from the config.berlin.freifunk.net wizard."
+
+#~ msgid "Am Freifunk-Netz teilnehmen"
+#~ msgstr "Participate in the Freifunk-Network"
+
+#~ msgid "Am Freifunk-Netz teilnehmen und Internet teilen"
+#~ msgstr "Participate in the Freifunk-Network and share Internet"
+
+#~ msgid ""
+#~ "Bitte beachte, dass der Router dann unter seiner neuen Freifunk-IP zu "
+#~ "erreichen ist. Von direkt per WLAN oder LAN angeschlossenen Rechnern ist "
+#~ "er auch unter dem Namen <em>frei.funk</em> zu erreichen."
+#~ msgstr ""
+#~ "Please mind, that the router router will be reachable by its new Freifunk-"
+#~ "IP-address. From devices connected by WiFi or Ethernet you could use "
+#~ "<em>frei.funk</em> also."
+
+#~ msgid "Dein Nickname"
+#~ msgstr "Your Nickname"
+
+#~ msgid "Dein Realname"
+#~ msgstr "Your Realname"
+
+#~ msgid ""
+#~ "Die DHCP-Einstellung regelt die Vergabe von IP-Adressen an Clients deines "
+#~ "Freifunk-Netzwerkes. Die noetige Angabe solltest du von config.berlin."
+#~ "freifunk.net bekommen haben. Dabei wird die CIDR-Schreibweise benutzt "
+#~ "(Beispiel: 10.42.42.42/28)."
+#~ msgstr ""
+#~ "The DHCP-options controls the distribution of IP-addresses to the clients "
+#~ "of your Freifunk-WiFi. You should have gotten the addresses from "
+#~ "<em>config.berlin.freifunk.net</em>. We use the CIDR-notation (i.e. "
+#~ "10.42.42.42/28)."
+
+#~ msgid ""
+#~ "Die Knoten des Freifunk-Netzes leiten die Daten auf der Basis des "
+#~ "kuerzesten Wegs und der hoechsten Bandbreite weiter. Dazu muss bekannt "
+#~ "sein, wieviel Bandbreite ins Internet du auf deinem Knoten zur Verfuegung "
+#~ "stellen kannst und willst. Typische Gesamtbandbreiten sind z.B. bei "
+#~ "<em>DSL 6000</em> 6.0 Mbit/s Download und 0.5 Mbit/s Upload oder bei "
+#~ "<em>VDSL 50000</em> 50.0 Mbit/s Download und 10.0 Mbit/s Upload. Am "
+#~ "besten testest du z.B. unter speedof.me mehrmals, wieviel Bandbreite dir "
+#~ "tatsaechlich zur Verfuegung steht. Dann gib hier an, wieviel du mit "
+#~ "deinen Nachbarn teilen moechtest. Sei grosszuegig, aber nicht "
+#~ "ueberbieten. :-)"
+#~ msgstr ""
+#~ "The nodes of the Freifunk network foward data based on shortest paths and "
+#~ "highest bandwidth. Therefor we need to know, how much bandwidth to the "
+#~ "internet there is and how much do you want to share. Typical values are "
+#~ "6.0 Mbit/s download and 0.5 Mbit/s upload with <em>DSL 6000</em> or 50.0 "
+#~ "Mbit/s download and 10.0 Mbit/s upload with <em>VDSL 50000</em>. "
+#~ "Preferably you test the actual bandwidth multiple time with a tool like "
+#~ "<em>speedof.me</em>. Then you can fill in how much bandwidth you are "
+#~ "willing to share with your peers. Please be generous, but don't "
+#~ "overestimate. :-)"
+
+#~ msgid ""
+#~ "Die SSID des Freifunk-WLAN-APs solltest du auf <em>berlin.freifunk.net</"
+#~ "em> lassen, sofern sich nicht in unmittelbarer Naehe ein weiterer Access "
+#~ "Point mit der gleichen SSID befindet. Auf diese Weise koennen sich Gaeste "
+#~ "z.B. mit ihrem Smartphone in der ganzen Gegend mit dem Freifunk-Netzwerk "
+#~ "verbinden, ohne spezielle Einstellungen fuer jeden einzelnen Router "
+#~ "vornehmen zu muessen. <br/>Diese Einstellung bezieht sich auf den WLAN-"
+#~ "AP, <em>nicht</em> das Adhoc-Netzwerk, das fuer das Freifunk-Meshing "
+#~ "benutzt wird."
+#~ msgstr ""
+#~ "You should leave the SSID at <em>berlin.freifunk.net</em>, as long as "
+#~ "there is not an access point with the same SSID nearby. Thus, people can "
+#~ "connect to the Freifunk network in the whole area, without having to "
+#~ "connect to every node individually. <br/>This option influences the WiFi-"
+#~ "AP, <em>not</em> the mesh-network for the mesh connections."
+
+#~ msgid "Download-Bandbreite in Mbit/s"
+#~ msgstr "Download bandwidth in Mbit/s"
+
+#~ msgid ""
+#~ "Du hast alle Einstellungen geschafft. Dein Router wird jetzt neu "
+#~ "gestartet. Am besten, du machst dir kurz einen Kaffee oder einen Tee :D "
+#~ "und sobald alle Lichter wieder blinken, bist du Freifunkerin!"
+#~ msgstr ""
+#~ "Done! You made all the necessary configuration. Your router will reboot "
+#~ "now. Consider drinking a cup of tea or coffee. :D Once all lights blink "
+#~ "again, you will be a Freifunkeer!"
+
+#~ msgid ""
+#~ "Erweitere das Freifunk-Netz. Du benoetigst dazu eine WLAN-Verbindung zu "
+#~ "einem anderen Freifunk-Router. Du kannst auf der Freifunk-Karte "
+#~ "nachschauen, wer in deiner Naehe ist, und sie kontaktieren, damit ihr die "
+#~ "Verbindung optimal ausrichten koennt."
+#~ msgstr ""
+#~ "Expand the Freifunk-Network. You need a WiFi-connection to another "
+#~ "Freifunk router for that. You can check whom is in your neighbourhood on "
+#~ "the Freifunk map. Then you can contact them, to adjust the mesh "
+#~ "connection to optimum."
+
+#~ msgid ""
+#~ "Es gibt auch Services im Freifunk-Netz. Ein Liste kannst du dir im "
+#~ "Freifunk-Hauptmenu unter <em>Services</em> ansehen, sobald dein Router "
+#~ "neugestartet hat."
+#~ msgstr ""
+#~ "There are even exclusive services in Freifunk-Network. You can get a list "
+#~ "of them in the Freifunk-main menu under <em>Services</em>, once your "
+#~ "router restarted."
+
+#~ msgid "Geographischer Breitengrad"
+#~ msgstr "Latitude"
+
+#~ msgid "Geographischer Längengrad"
+#~ msgstr "Longitude"
+
+#~ msgid ""
+#~ "Herzlichen Glueckwunsch! <br/>Du hast deinen Router erfolgreich mit der "
+#~ "Freifunk-Firmware ausgestattet. Dieser Assistent hilft dir beim "
+#~ "Einrichten deines Routers. Wenn du keine Hilfe brauchst, kannst du in der "
+#~ "Administrationsoberfläche die Einstellungen auch alleine vornehmen. <br/"
+#~ ">Aendere hier zunaechst dein Password. Bitte waehle ein sicheres "
+#~ "Passwort, da der Router nach aussen sichtbar ist. Spaeter findest du "
+#~ "diese Option im Bereich <em>System &gt; Administration.</em>"
+#~ msgstr ""
+#~ "Congratulations! <br/>You've installed the Freifunk firmware successfully "
+#~ "on your device. This assistant helps you with the configuration. If you "
+#~ "don't need help with that, you can safely skip this, go to the admin "
+#~ "interface and do the configuration on your own. <br/>Beforehand, change "
+#~ "your password please. Please use a strong password, because the router is "
+#~ "visible to the Freifunk network. Later on, you will find this option at "
+#~ "<em>System &gt; Administration.</em>"
+
+#~ msgid "Höhe über Grund"
+#~ msgstr "Height above the ground"
+
+#~ msgid ""
+#~ "Im Folgenden werden die IPs eingetragen, die du vom Wizard unter config."
+#~ "berlin.freifunk.net bekommen hast. Ueber diese Adresse(n) verbindet sich "
+#~ "dein Router mit anderen Freifunk-Routern in deiner Naehe. Spaeter kannst "
+#~ "du dir die Einstellungen unter <em>Network &gt; Interfaces und Network "
+#~ "&gt; Wireless</em> anschauen."
+#~ msgstr ""
+#~ "Next, we enter the IP-addresses that we got from <em>config.berlin."
+#~ "freifunk.net</em>. With this addresses, your router connects to other "
+#~ "Freifunk routers in range. You can display them at <em>Network &gt; "
+#~ "Interfaces und Network &gt; Wireless</em> later on."
+
+#~ msgid ""
+#~ "Im Folgenden wird dein Schluessel zum Tunnel/VPN gebraucht. Du entpackst "
+#~ "die Datei, die dir zugeschickt wurde, und lädst hier dein Zertifikat und "
+#~ "deinen Schlüssel hoch."
+#~ msgstr ""
+#~ "Now we need the key for the tunnel/VPN. Please unzip the file you got by "
+#~ "email and upload the certificate and the key here."
+
+#~ msgid "Monitoring anschalten"
+#~ msgstr "Enable monitoring"
+
+#~ msgid "Name dieses Freifunk-Knotens"
+#~ msgstr "Name of this Freifunk-node"
+
+#~ msgid "Schluessel loeschen und erneut hochladen"
+#~ msgstr "Delete key and upload again"
+
+#~ msgid "Standort"
+#~ msgstr "Location"
+
+#~ msgid ""
+#~ "Unterstütze die Community, indem du dein Internet im Freifunk-Netzwerk "
+#~ "freigibst. Diese Option ist sowohl mit als auch ohne Verbindung zu "
+#~ "anderen Freifunk-Routern sinnvoll."
+#~ msgstr ""
+#~ "Support the community by sharing your internet to the Freifunk-Network. "
+#~ "This option is sensible in any context, whether you are connected to "
+#~ "other Freifunk-Nodes or not."
+
+#~ msgid "Upload-Bandbreite in Mbit/s"
+#~ msgstr "Upload bandwidth in Mbit/s"
+
+#~ msgid ""
+#~ "Wenn Du hier den Haken setzt, werden statistische Daten (RAM-Auslastung, "
+#~ "CPU-Auslastung, Bandbreitennutzung etc.) dieses Routers erhoben und in "
+#~ "der Oberflaeche des Routers angezeigt sowie an monitor.berlin.freifunk."
+#~ "net geschickt. Es werden keine Statistiken erhoben, wenn du den Haken "
+#~ "nicht setzt. Du kannst die Statistiken spaeter ueber Administration &gt; "
+#~ "Statistics &gt; Collectd einschalten. Auf Routern mit nur 4MB ROM steht "
+#~ "das Monitoring nicht zur Verfuegung. Auf Routern mit nur 32MB RAM werden "
+#~ "die Daten nur auf monitor.berlin.freifunk.net dargestellt, nicht lokal in "
+#~ "der Router-Oberflaeche."
+#~ msgstr ""
+#~ "By enabling this option, the router shows statistic data (like memory-"
+#~ "usage, CPU-usage, bandwidth-use, etc) in the user interface and sends "
+#~ "them to monitor.berlin.freifunk.net. The router won't log statistic data, "
+#~ "if you don't check the box. Under <em>Administration &gt; Statistics &gt; "
+#~ "Collectd</em> you can activate the statistics afterwards. On routers with "
+#~ "only 4MiB of flash, monitoring is not available. On routers with only "
+#~ "32MiB of memory, statistics data will be only send to monitor.berlin."
+#~ "freifunk.net, but not displayed in the local user interface."
+
+#~ msgid ""
+#~ "Wenn du möchtest, kannst du hier deine Kontaktdaten eingeben. Die "
+#~ "Kontaktdaten werden auf der Infoseite des Routers sowie auf der Freifunk-"
+#~ "Karte angezeigt. So koennen dich andere Freifunkerinnen finden und dich "
+#~ "ansprechen, falls sie Ihren Router mit deinem verbinden moechten. <br/"
+#~ ">Falls du hier nichts angeben möchtest, kannst du den Punkt auch einfach "
+#~ "ueberspringen oder einzelne Felder leerlassen. <br/>Den (eindeutigen) "
+#~ "Namen dieses Freifunk-Knotens musst du allerdings setzen. <br/>Du kannst "
+#~ "diese Daten auch später noch ändern, indem du nur diese Seite des "
+#~ "Assistenten benutzt."
+#~ msgstr ""
+#~ "If you like, you can paste your contact details here. Those get displayed "
+#~ "on the routers info page and the Freifunk map. This way, other Freifunk "
+#~ "peers can contact you if they would like to make a mesh-connection to "
+#~ "you. If you don't like to give that information, you could simply skip "
+#~ "that page or leave some forms empty. But you must set the (unique) Name "
+#~ "of this Freifunk-node. You can update this data later on by using only "
+#~ "the first page of this assistant."
 
 #~ msgid ""
 #~ "The wireless interfaces which are built into the router can mesh with "

--- a/luci/luci-app-ffwizard-falter/po/templates/ffwizard-falter.pot
+++ b/luci/luci-app-ffwizard-falter/po/templates/ffwizard-falter.pot
@@ -31,43 +31,30 @@ msgstr ""
 msgid "Ad-Hoc"
 msgstr ""
 
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:68
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:54
 msgid "Ad-Hoc (outdated)"
 msgstr ""
 
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:68
-msgid "Ad-Hoc (veraltet)"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:10
-msgid ""
-"Als naechstes kommen die Einstellungen für das Freifunk-Netzwerk. Halte die "
-"IPs bereit, die du ueber den Wizard von config.berlin.freifunk.net bekommen "
-"hast."
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:19
-msgid "Am Freifunk-Netz teilnehmen"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:36
-msgid "Am Freifunk-Netz teilnehmen und Internet teilen"
-msgstr ""
-
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/optionalConfigs.lua:17
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:25
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:50
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:47
 msgid "Back"
 msgstr ""
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm:16
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/enableStats.htm:3
 msgid ""
-"Bitte beachte, dass der Router dann unter seiner neuen Freifunk-IP zu "
-"erreichen ist. Von direkt per WLAN oder LAN angeschlossenen Rechnern ist er "
-"auch unter dem Namen <em>frei.funk</em> zu erreichen."
+"By enabling this option, the router shows statistic data (like memory-usage, "
+"CPU-usage, bandwidth-use, etc) in the user interface and sends them to "
+"monitor.berlin.freifunk.net. The router won't log statistic data, if you "
+"don't check the box. Under <em>Administration &gt; Statistics &gt; Collectd</"
+"em> you can activate the statistics afterwards. On routers with only 4MiB of "
+"flash, monitoring is not available. On routers with only 32MiB of memory, "
+"statistics data will be only send to monitor.berlin.freifunk.net, but not "
+"displayed in the local user interface."
 msgstr ""
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:51
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:48
 msgid "Cancel"
 msgstr ""
 
@@ -75,125 +62,76 @@ msgstr ""
 msgid "Confirmation"
 msgstr ""
 
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/welcome.htm:3
+msgid ""
+"Congratulations! <br/>You've installed the Freifunk firmware successfully on "
+"your device. This assistant helps you with the configuration. If you don't "
+"need help with that, you can safely skip this, go to the admin interface and "
+"do the configuration on your own. <br/>Beforehand, change your password "
+"please. Please use a strong password, because the router is visible to the "
+"Freifunk network. Later on, you will find this option at <em>System &gt; "
+"Administration.</em>"
+msgstr ""
+
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:93
-msgid "DHCP-Network"
+msgid "DHCP Network"
 msgstr ""
 
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:33
-msgid "Dein Nickname"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:39
-msgid "Dein Realname"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/ipinfo.htm:13
-msgid ""
-"Die DHCP-Einstellung regelt die Vergabe von IP-Adressen an Clients deines "
-"Freifunk-Netzwerkes. Die noetige Angabe solltest du von config.berlin."
-"freifunk.net bekommen haben. Dabei wird die CIDR-Schreibweise benutzt "
-"(Beispiel: 10.42.42.42/28)."
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/shareBandwidth.htm:3
-msgid ""
-"Die Knoten des Freifunk-Netzes leiten die Daten auf der Basis des kuerzesten "
-"Wegs und der hoechsten Bandbreite weiter. Dazu muss bekannt sein, wieviel "
-"Bandbreite ins Internet du auf deinem Knoten zur Verfuegung stellen kannst "
-"und willst. Typische Gesamtbandbreiten sind z.B. bei <em>DSL 6000</em> 6.0 "
-"Mbit/s Download und 0.5 Mbit/s Upload oder bei <em>VDSL 50000</em> 50.0 Mbit/"
-"s Download und 10.0 Mbit/s Upload. Am besten testest du z.B. unter speedof."
-"me mehrmals, wieviel Bandbreite dir tatsaechlich zur Verfuegung steht. Dann "
-"gib hier an, wieviel du mit deinen Nachbarn teilen moechtest. Sei "
-"grosszuegig, aber nicht ueberbieten. :-)"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/ipinfo.htm:3
-msgid ""
-"Die SSID des Freifunk-WLAN-APs solltest du auf <em>berlin.freifunk.net</em> "
-"lassen, sofern sich nicht in unmittelbarer Naehe ein weiterer Access Point "
-"mit der gleichen SSID befindet. Auf diese Weise koennen sich Gaeste z.B. mit "
-"ihrem Smartphone in der ganzen Gegend mit dem Freifunk-Netzwerk verbinden, "
-"ohne spezielle Einstellungen fuer jeden einzelnen Router vornehmen zu "
-"muessen. <br/>Diese Einstellung bezieht sich auf den WLAN-AP, <em>nicht</em> "
-"das Adhoc-Netzwerk, das fuer das Freifunk-Meshing benutzt wird."
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua:16
-msgid "Download-Bandbreite in Mbit/s"
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/vpncertreupload.htm:3
+msgid "Delete key and upload again"
 msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm:11
 msgid ""
-"Du hast alle Einstellungen geschafft. Dein Router wird jetzt neu gestartet. "
-"Am besten, du machst dir kurz einen Kaffee oder einen Tee :D und sobald alle "
-"Lichter wieder blinken, bist du Freifunkerin!"
+"Done! You made all the necessary configuration. Your router will reboot now. "
+"Consider drinking a cup of tea or coffee. :D Once all lights blink again, "
+"you will be a Freifunkeer!"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua:16
+msgid "Download bandwidth in Mbit/s"
 msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:45
 msgid "E-Mail"
 msgstr ""
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:24
-msgid ""
-"Erweitere das Freifunk-Netz. Du benoetigst dazu eine WLAN-Verbindung zu "
-"einem anderen Freifunk-Router. Du kannst auf der Freifunk-Karte nachschauen, "
-"wer in deiner Naehe ist, und sie kontaktieren, damit ihr die Verbindung "
-"optimal ausrichten koennt."
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/optionalConfigs.lua:26
+msgid "Enable monitoring"
 msgstr ""
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm:22
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:23
 msgid ""
-"Es gibt auch Services im Freifunk-Netz. Ein Liste kannst du dir im Freifunk-"
-"Hauptmenu unter <em>Services</em> ansehen, sobald dein Router neugestartet "
-"hat."
+"Expand the Freifunk-Network. You need a WiFi-connection to another Freifunk "
+"router for that. You can check whom is in your neighbourhood on the Freifunk "
+"map. Then you can contact them, to adjust the mesh connection to optimum."
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:86
+msgid "Freifunk SSID"
 msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:16
 msgid "Freifunk-Community"
 msgstr ""
 
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:86
-msgid "Freifunk-SSID"
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:69
+msgid "Height above the ground"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/generalInfo.htm:3
+msgid ""
+"If you like, you can paste your contact details here. Those get displayed on "
+"the routers info page and the Freifunk map. This way, other Freifunk peers "
+"can contact you if they would like to make a mesh-connection to you. If you "
+"don't like to give that information, you could simply skip that page or "
+"leave some forms empty. But you must set the (unique) Name of this Freifunk-"
+"node. You can update this data later on by using the contact page in the "
+"routers web interface at <em>Freifunk &gt; Contact</em>."
 msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:57
-msgid "Geographischer Breitengrad"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:63
-msgid "Geographischer Längengrad"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/welcome.htm:3
-msgid ""
-"Herzlichen Glueckwunsch! <br/>Du hast deinen Router erfolgreich mit der "
-"Freifunk-Firmware ausgestattet. Dieser Assistent hilft dir beim Einrichten "
-"deines Routers. Wenn du keine Hilfe brauchst, kannst du in der "
-"Administrationsoberfläche die Einstellungen auch alleine vornehmen. <br/"
-">Aendere hier zunaechst dein Password. Bitte waehle ein sicheres Passwort, "
-"da der Router nach aussen sichtbar ist. Spaeter findest du diese Option im "
-"Bereich <em>System &gt; Administration.</em>"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:69
-msgid "Höhe über Grund"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/meshipinfo.htm:3
-msgid ""
-"Im Folgenden werden die IPs eingetragen, die du vom Wizard unter config."
-"berlin.freifunk.net bekommen hast. Ueber diese Adresse(n) verbindet sich "
-"dein Router mit anderen Freifunk-Routern in deiner Naehe. Spaeter kannst du "
-"dir die Einstellungen unter <em>Network &gt; Interfaces und Network &gt; "
-"Wireless</em> anschauen."
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/vpninfo.htm:3
-msgid ""
-"Im Folgenden wird dein Schluessel zum Tunnel/VPN gebraucht. Du entpackst die "
-"Datei, die dir zugeschickt wurde, und lädst hier dein Zertifikat und deinen "
-"Schlüssel hoch."
+msgid "Latitude"
 msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua:42
@@ -204,20 +142,24 @@ msgstr ""
 msgid "Local Key"
 msgstr ""
 
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:51
+msgid "Location"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:63
+msgid "Longitude"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:48
+msgid "Mesh IP"
+msgstr ""
+
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:61
 msgid "Mesh Mode"
 msgstr ""
 
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:48
-msgid "Mesh-IP"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/optionalConfigs.lua:26
-msgid "Monitoring anschalten"
-msgstr ""
-
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:27
-msgid "Name dieses Freifunk-Knotens"
+msgid "Name of this Freifunk node"
 msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/changePassword.lua:5
@@ -226,28 +168,81 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:10
+msgid ""
+"Next we set the options for the Freifunk network. Have the IPs ready that "
+"you received from the config.berlin.freifunk.net wizard"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/meshipinfo.htm:3
+msgid ""
+"Next, we enter the IP-addresses that we got from <em>config.berlin.freifunk."
+"net</em>. With this addresses, your router connects to other Freifunk "
+"routers in range. You can display them at <em>Network &gt; Interfaces and "
+"Network &gt; Wireless</em> later on."
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/vpninfo.htm:3
+msgid ""
+"Now we need the key for the tunnel/VPN. Please unzip the file you got by "
+"email and upload the certificate and the key here."
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:18
+msgid "Participate in the Freifunk-Network"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:33
+msgid "Participate in the Freifunk-Network and share Internet"
+msgstr ""
+
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/changePassword.lua:18
 msgid "Password"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm:15
+msgid ""
+"Please mind, that the router router will be reachable by its new Freifunk-IP-"
+"address. From devices connected by WiFi or Ethernet you could use <em>frei."
+"funk</em> also."
 msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/wireless.lua:24
 msgid "Save and reboot"
 msgstr ""
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/vpncertreupload.htm:3
-msgid "Schluessel loeschen und erneut hochladen"
-msgstr ""
-
-#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:51
-msgid "Standort"
-msgstr ""
-
 #: luci/luci-app-ffwizard-falter/root/usr/share/rpcd/acl.d/luci-app-ffwizard-falter.json:3
 msgid "Super user access role"
 msgstr ""
 
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:38
+msgid ""
+"Support the community by sharing your internet to the Freifunk-Network. This "
+"option is sensible in any context, whether you are connected to other "
+"Freifunk-Nodes or not."
+msgstr ""
+
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:42
 msgid "The"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/ipinfo.htm:9
+msgid ""
+"The DHCP-options controls the distribution of IP-addresses to the clients of "
+"your Freifunk-WiFi. You should have gotten the addresses from <em>config."
+"berlin.freifunk.net</em>. We use the CIDR-notation (i.e. 10.42.42.42/28)."
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/shareBandwidth.htm:3
+msgid ""
+"The nodes of the Freifunk network forward data based on shortest paths and "
+"highest bandwidth. Therefore we need to know, how much bandwidth to the "
+"internet there is and how much do you want to share. Typical values are 6.0 "
+"Mbit/s download and 0.5 Mbit/s upload with <em>DSL 6000</em> or 50.0 Mbit/s "
+"download and 10.0 Mbit/s upload with <em>VDSL 50000</em>. Preferably you "
+"test the actual bandwidth multiple times with a tool like <em>speedof.me</"
+"em>. Then you can fill in how much bandwidth you are willing to share with "
+"your peers. Please be generous, but don't overestimate. :-)"
 msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:5
@@ -262,11 +257,11 @@ msgid ""
 "at a later time to change these settings.</em>"
 msgstr ""
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/decide.htm:41
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/reboot.htm:19
 msgid ""
-"Unterstütze die Community, indem du dein Internet im Freifunk-Netzwerk "
-"freigibst. Diese Option ist sowohl mit als auch ohne Verbindung zu anderen "
-"Freifunk-Routern sinnvoll."
+"There are even exclusive services in Freifunk-Network. You can get a list of "
+"them in the Freifunk-main menu under <em>Services</em>, once your router "
+"restarted."
 msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:4
@@ -274,33 +269,24 @@ msgid "Update Wireless-Mesh Settings"
 msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/shareInternet.lua:23
-msgid "Upload-Bandbreite in Mbit/s"
+msgid "Upload bandwidth in Mbit/s"
 msgstr ""
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/enableStats.htm:3
+#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/ipinfo.htm:3
 msgid ""
-"Wenn Du hier den Haken setzt, werden statistische Daten (RAM-Auslastung, CPU-"
-"Auslastung, Bandbreitennutzung etc.) dieses Routers erhoben und in der "
-"Oberflaeche des Routers angezeigt sowie an monitor.berlin.freifunk.net "
-"geschickt. Es werden keine Statistiken erhoben, wenn du den Haken nicht "
-"setzt. Du kannst die Statistiken spaeter ueber Administration &gt; "
-"Statistics &gt; Collectd einschalten. Auf Routern mit nur 4MB ROM steht das "
-"Monitoring nicht zur Verfuegung. Auf Routern mit nur 32MB RAM werden die "
-"Daten nur auf monitor.berlin.freifunk.net dargestellt, nicht lokal in der "
-"Router-Oberflaeche."
+"You should leave the SSID at <em>berlin.freifunk.net</em>, as long as there "
+"is not an access point with the same SSID nearby. Thus, people can connect "
+"to the Freifunk network in the whole area, without having to connect to "
+"every node individually. <br/>This option influences the WiFi-AP, <em>not</"
+"em> the mesh-network for the mesh connections."
 msgstr ""
 
-#: luci/luci-app-ffwizard-falter/luasrc/view/freifunk/assistent/snippets/generalInfo.htm:3
-msgid ""
-"Wenn du möchtest, kannst du hier deine Kontaktdaten eingeben. Die "
-"Kontaktdaten werden auf der Infoseite des Routers sowie auf der Freifunk-"
-"Karte angezeigt. So koennen dich andere Freifunkerinnen finden und dich "
-"ansprechen, falls sie Ihren Router mit deinem verbinden moechten. <br/>Falls "
-"du hier nichts angeben möchtest, kannst du den Punkt auch einfach "
-"ueberspringen oder einzelne Felder leerlassen. <br/>Den (eindeutigen) Namen "
-"dieses Freifunk-Knotens musst du allerdings setzen. <br/>Du kannst diese "
-"Daten auch später noch ändern, indem du nur diese Seite des Assistenten "
-"benutzt."
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:33
+msgid "Your Nickname"
+msgstr ""
+
+#: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua:39
+msgid "Your Realname"
 msgstr ""
 
 #: luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/upgrades/005-wireless-mesh.lua:43


### PR DESCRIPTION
LuCI doesn't provide English translation packages anymore and
assumes, that English is the base language. Thus changing.

fixes #246 