### PR TITLE
falter-berlin-ssid-changer: several fixes

### DIFF
--- a/packages/falter-berlin-ssid-changer/Makefile
+++ b/packages/falter-berlin-ssid-changer/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-berlin-ssid-changer
-PKG_VERSION:=1
+PKG_VERSION:=2
 
 include $(INCLUDE_DIR)/package.mk
 
 define Package/falter-berlin-ssid-changer
   SECTION:=falter-berlin
   CATEGORY:=falter-berlin
-  TITLE:=Freifunk Berlin ssid changer
+  TITLE:=Freifunk Berlin SSID Changer
   URL:=http://github.com/Freifunk-Spalter/packages
   PKGARCH:=all
   EXTRA_DEPENDS:=pingcheck
@@ -32,6 +32,8 @@ define Package/falter-berlin-ssid-changer/install
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/net
 	$(CP) ./files/hotplug.d/* $(1)/etc/hotplug.d/net
 	$(CP) ./files/lib $(1)/lib
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(CP) ./files/post-inst.sh $(1)/etc/uci-defaults/90_ssidchanger-post-inst.sh
 endef
 
 $(eval $(call BuildPackage,falter-berlin-ssid-changer))

--- a/packages/falter-berlin-ssid-changer/files/hotplug.d/30-ssid-changer
+++ b/packages/falter-berlin-ssid-changer/files/hotplug.d/30-ssid-changer
@@ -8,14 +8,35 @@
 . /lib/functions.sh
 . /lib/lib_ssid-changer.sh
 
-# exit early, if ssid-changer is disabled or interface doesn't matter for wifi
-ENABLED=$(uci_get ffwizard ssid_changer enabled)
-if [ $? = 1 ]; then ENABLED=1; fi # default to enbaled, if value not set
-if [ $ENABLED = 0 ]; then
+# don't run ssid_changer, if the wizard wasn't run yet.
+if [ ! -f /etc/config/ffwizard ]; then
+    log "ffwizard didn't run yet. Cancelling scripts run."
     exit 0
 fi
-if [ "$INTERFACE" != "ffuplink" ] || !(echo "$INTERFACE" | grep -Eq 'tnl_.*'); then
+
+# if ssid_changer wasn't configured by wizard, add it to ffwizard-file
+if ! grep ssid_changer /etc/config/ffwizard; then
+    log "No ssid-changer config found. Writing one to /etc/config/ffwizard."
+    uci_add ffwizard ssid_changer ssid_changer
+    uci_set ffwizard ssid_changer enabled 1
+    uci_commit
+fi
+
+# exit early, if ssid-changer is disabled or interface doesn't matter for wifi
+ENABLED=$(uci_get ffwizard ssid_changer enabled)
+if [ $? = 1 ]; then ENABLED=1; fi # default to enabled, if value not set
+if [ "$ENABLED" = 0 ]; then
     exit 0
+fi
+# We care for changes on ffuplink and tnl_.* interfaces only. For every interface not matching this,
+# do an early exit
+if [ "$INTERFACE" != "ffuplink" ] && ! (echo "$INTERFACE" | grep -Eq 'tnl_.*'); then
+    exit 0
+fi
+
+# delay execution for up to 280 seconds, to evenly distribute the pings
+if [ "$DELAY" ]; then
+    sleep $(( $( dd if=/dev/urandom bs=2 count=1 2>&- | hexdump | if read -r line; then echo "0x${line#* }"; fi ) % 280))
 fi
 
 # check, if we are online

--- a/packages/falter-berlin-ssid-changer/files/post-inst.sh
+++ b/packages/falter-berlin-ssid-changer/files/post-inst.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+
+# if ssid-changer is not present in crontab, include it.
+crontab -l | grep ssid-changer >>/dev/null
+if [ $? != 0 ]; then
+    # check every 5 minutes, if we can still reach the internet, but delay
+    # execution randomly, to achieve evenly distribution
+    echo '# check every 5 minutes, if we can still reach the internet, but delay execution randomly, to achieve evenly distribution' >>/etc/crontabs/root
+    echo '*/5 * * * *      test -e /etc/hotplug.d/net/30-ssid-changer && DELAY=some INTERFACE=ffuplink sh /etc/hotplug.d/net/30-ssid-changer' >>/etc/crontabs/root
+
+    /etc/init.d/cron restart
+fi


### PR DESCRIPTION
In the merged state before, the ssid-changer was only functional, if there did happen a change in the state of interfaces. But if a router started without having internet connectivity, it wasn't working at all.

This commit adds a check for connectivity running every 5 minutes, hopefully increasing the user experience a lot.

Signed-off-by: Martin Hübner <martin.hubner@web.de>
