### PR TITLE
[21.02] falter-berlin-tunnelmanager: wait for mesh daemons to be started

### DIFF
--- a/packages/falter-berlin-tunnelmanager/files/tunnelmanager.init
+++ b/packages/falter-berlin-tunnelmanager/files/tunnelmanager.init
@@ -49,6 +49,23 @@ tm_start() {
     procd_close_instance
 }
 
+wait_for_babeld()
+{
+	ubus -t 60 wait_for babeld 2>/dev/null
+}
+
+wait_for_olsrd()
+{
+	ubus -t 60 wait_for olsrd 2>/dev/null
+}
+
+boot()
+{
+    wait_for_babeld
+    wait_for_olsrd
+    start "$@"
+}
+
 start_service() {
     config_load tunnelmanager
     config_foreach tm_start tunnelmanager


### PR DESCRIPTION
Wait for mesh daemons running before starting tunnelmanager.

