### PR TITLE
workflows: add ShellCheck and ignore existing files with issues

### DIFF
--- a/.github/workflows/shellcheck-lint.yml
+++ b/.github/workflows/shellcheck-lint.yml
@@ -1,0 +1,45 @@
+---
+name: ShellCheck Lint
+on: [push, pull_request]  # yamllint disable-line rule:truthy
+
+jobs:
+  build:
+    name: Lint ShellCheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Lint ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          ignore_paths: >  # TODO: fix the issues in all these files and remove the lines afterwards
+            ./build/build.sh
+            ./fetch_translation_tools.sh
+            ./luci/luci-app-falter-owm/files/owm.sh
+            ./luci/luci-app-ffwizard-falter/root/usr/libexec/rpcd/ffwizard-berlin
+            ./packages/falter-berlin-admin-keys/files/register_keys.sh
+            ./packages/falter-berlin-autoupdate/files/autoupdate.sh
+            ./packages/falter-berlin-autoupdate/files/lib_autoupdate.sh
+            ./packages/falter-berlin-autoupdate/files/post-inst.sh
+            ./packages/falter-berlin-bbbdigger/files/postinst.sh
+            ./packages/falter-berlin-dhcp-defaults/files/etc/init.d/ff_dnsmasq_reload
+            ./packages/falter-berlin-lib-guard/files/lib/functions/guard.sh
+            ./packages/falter-berlin-migration/files/lib/functions/semver.sh
+            ./packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+            ./packages/falter-berlin-network-defaults/hotplug.d/iface/60-ffuplink_policyrouting
+            ./packages/falter-berlin-network-defaults/lib/functions/freifunk-berlin-network.sh
+            ./packages/falter-berlin-network-defaults/uci-defaults/freifunk-berlin-correct-nsm2-txpower
+            ./packages/falter-berlin-ssid-changer/files/lib/lib_ssid-changer.sh
+            ./packages/falter-berlin-ssid-changer/files/post-inst.sh
+            ./packages/falter-berlin-system-defaults/uci-defaults/freifunk-berlin-system-defaults
+            ./packages/falter-berlin-tunnelmanager/files/down.sh
+            ./packages/falter-berlin-tunnelmanager/files/tunnelman.sh
+            ./packages/falter-berlin-tunnelmanager/files/up.sh
+            ./packages/falter-berlin-uplink-notunnel/files/etc/pingcheck/offline.d/60-freifunk-notunnel
+            ./packages/falter-berlin-uplink-notunnel/files/etc/pingcheck/online.d/60-freifunk-notunnel
+            ./packages/falter-common/files-common/etc/init.d/freifunk
+            ./packages/falter-common/files-common/etc/profile.d/10_dynbanner.sh
+            ./packages/falter-common/files-common/usr/bin/ffdzero
+            ./packages/falter-common/files-common/usr/bin/watch.sh
+            ./packages/falter-policyrouting/files/etc/init.d/freifunk-policyrouting


### PR DESCRIPTION
This adds ShellCheck to the repository, but ignores the files with issues for now. The idea is to prevent ShellCheck errors in new code, but allow old code to be fixed over time.

Signed-off-by: Tobias Schwarz <info@tobias-schwarz.com>