### PR TITLE
Makefiles: update falter-package url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,8 @@ You can add the signed-off-by line automatically via `git commit -s`.
 ## Any contributions you make will be under the GPLv3 Software License
 In short, when you submit code changes, your submissions are understood to be under the same [GPLv3 License](http://www.gnu.org/licenses/gpl-3.0.html) that covers the project. Feel free to contact the maintainers if that's a concern.
 
-## Report bugs using Github's [issues](https://github.com/Freifunk-Spalter/packages/issues)
-We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/Freifunk-Spalter/packages/issues/new); it's that easy!
+## Report bugs using Github's [issues](https://github.com/freifunk-berlin/falter-packages/issues)
+We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/freifunk-berlin/falter-packages/issues/new); it's that easy!
 
 ## Write bug reports with detail, background, and sample code
 A good bug report helps the maintainers a lot to understand you problem and fix it faster.

--- a/packages/falter-berlin-admin-keys/Makefile
+++ b/packages/falter-berlin-admin-keys/Makefile
@@ -9,7 +9,7 @@ define Package/falter-berlin-admin-keys
   SECTION:=falter-berlin
   CATEGORY:=falter-berlin
   TITLE:=Freifunk Berlin Administrator SSH Keys
-  URL:=http://github.com/Freifunk-Spalter/packages
+  URL:=https://github.com/freifunk-berlin/falter-packages
   PKGARCH:=all
 endef
 

--- a/packages/falter-berlin-autoupdate/Makefile
+++ b/packages/falter-berlin-autoupdate/Makefile
@@ -8,7 +8,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/falter-berlin-autoupdate/default
   SECTION:=falter-berlin
   CATEGORY:=falter-berlin
-  URL:=http://github.com/Freifunk-Spalter/packages
+  URL:=https://github.com/freifunk-berlin/falter-packages
   PKGARCH:=all
 endef
 

--- a/packages/falter-berlin-bbbdigger/Makefile
+++ b/packages/falter-berlin-bbbdigger/Makefile
@@ -18,7 +18,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/falter-berlin-bbbdigger/default
   SECTION:=falter-berlin
   CATEGORY:=falter-berlin
-  URL:=http://github.com/Freifunk-Spalter/packages
+  URL:=https://github.com/freifunk-berlin/falter-packages
   PKGARCH:=all
 endef
 

--- a/packages/falter-berlin-dhcp-defaults/Makefile
+++ b/packages/falter-berlin-dhcp-defaults/Makefile
@@ -9,7 +9,7 @@ define Package/falter-berlin-dhcp-defaults
   SECTION:=falter-berlin
   CATEGORY:=falter-berlin
   TITLE:=Freifunk Berlin dhcp default configuration
-  URL:=http://github.com/Freifunk-Spalter/packages
+  URL:=https://github.com/freifunk-berlin/falter-packages
   EXTRA_DEPENDS:=dnsmasq, falter-berlin-lib-guard
   PKGARCH:=all
 endef

--- a/packages/falter-berlin-freifunk-defaults/Makefile
+++ b/packages/falter-berlin-freifunk-defaults/Makefile
@@ -10,7 +10,7 @@ define Package/falter-berlin-freifunk-defaults
   SECTION:=falter-berlin
   CATEGORY:=falter-berlin
   TITLE:=Freifunk Berlin freifunk default configuration
-  URL:=http://github.com/Freifunk-Spalter/packages
+  URL:=https://github.com/freifunk-berlin/falter-packages
   PKGARCH:=all
 endef
 

--- a/packages/falter-berlin-lib-guard/Makefile
+++ b/packages/falter-berlin-lib-guard/Makefile
@@ -9,7 +9,7 @@ define Package/falter-berlin-lib-guard
   SECTION:=falter-berlin
   CATEGORY:=falter-berlin
   TITLE:=Freifunk Berlin guard function
-  URL:=http://github.com/Freifunk-Spalter/packages
+  URL:=https://github.com/freifunk-berlin/falter-packages
   PKGARCH:=all
 endef
 

--- a/packages/falter-berlin-migration/Makefile
+++ b/packages/falter-berlin-migration/Makefile
@@ -11,7 +11,7 @@ define Package/falter-berlin-migration
   SECTION:=falter-berlin
   CATEGORY:=falter-berlin
   TITLE:=Freifunk Berlin configuration migration script
-  URL:=http://github.com/Freifunk-Spalter/packages
+  URL:=https://github.com/freifunk-berlin/falter-packages
   EXTRA_DEPENDS:=falter-berlin-lib-guard
   PKGARCH:=all
 endef

--- a/packages/falter-berlin-network-defaults/Makefile
+++ b/packages/falter-berlin-network-defaults/Makefile
@@ -9,7 +9,7 @@ define Package/falter-berlin-network-defaults
   SECTION:=falter-berlin
   CATEGORY:=falter-berlin
   TITLE:=Freifunk Berlin network default configuration
-  URL:=http://github.com/Freifunk-Spalter/packages
+  URL:=https://github.com/freifunk-berlin/falter-packages
   EXTRA_DEPENDS:=falter-berlin-lib-guard, pingcheck
   PKGARCH:=all
 endef

--- a/packages/falter-berlin-olsrd-defaults/Makefile
+++ b/packages/falter-berlin-olsrd-defaults/Makefile
@@ -9,7 +9,7 @@ define Package/falter-berlin-olsrd-defaults
   SECTION:=falter-berlin
   CATEGORY:=falter-berlin
   TITLE:=Freifunk Berlin olsrd default configuration
-  URL:=http://github.com/Freifunk-Spalter/packages
+  URL:=https://github.com/freifunk-berlin/falter-packages
   EXTRA_DEPENDS+=olsrd, falter-berlin-lib-guard
   PKGARCH:=all
 endef

--- a/packages/falter-berlin-service-registrar/Makefile
+++ b/packages/falter-berlin-service-registrar/Makefile
@@ -11,7 +11,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/falter-berlin-service-registrar/default
   SECTION:=falter-berlin
   CATEGORY:=falter-berlin
-  URL:=http://github.com/Freifunk-Spalter/packages
+  URL:=https://github.com/freifunk-berlin/falter-packages
   PKGARCH:=all
   EXTRA_DEPENDS:=olsrd, olsrd-mod-nameservice, uhttpd, uci
 endef

--- a/packages/falter-berlin-ssid-changer/Makefile
+++ b/packages/falter-berlin-ssid-changer/Makefile
@@ -9,7 +9,7 @@ define Package/falter-berlin-ssid-changer
   SECTION:=falter-berlin
   CATEGORY:=falter-berlin
   TITLE:=Freifunk Berlin SSID Changer
-  URL:=http://github.com/Freifunk-Spalter/packages
+  URL:=https://github.com/freifunk-berlin/falter-packages
   PKGARCH:=all
   EXTRA_DEPENDS:=pingcheck
 endef

--- a/packages/falter-berlin-statistics-defaults/Makefile
+++ b/packages/falter-berlin-statistics-defaults/Makefile
@@ -10,7 +10,7 @@ define Package/falter-berlin-statistics-defaults
   SECTION:=falter-berlin
   CATEGORY:=falter-berlin
   TITLE:=Freifunk Berlin statistics default configuration
-  URL:=http://github.com/Freifunk-Spalter/packages
+  URL:=https://github.com/freifunk-berlin/falter-packages
   EXTRA_DEPENDS:=olsrd-mod-txtinfo, falter-berlin-lib-guard
   PKGARCH:=all
 endef

--- a/packages/falter-berlin-system-defaults/Makefile
+++ b/packages/falter-berlin-system-defaults/Makefile
@@ -10,7 +10,7 @@ define Package/falter-berlin-system-defaults
   SECTION:=falter-berlin
   CATEGORY:=falter-berlin
   TITLE:=Freifunk Berlin system default configuration
-  URL:=http://github.com/Freifunk-Spalter/packages
+  URL:=https://github.com/freifunk-berlin/falter-packages
   EXTRA_DEPENDS:=falter-berlin-lib-guard
   PKGARCH:=all
 endef

--- a/packages/falter-berlin-tunnelmanager/Makefile
+++ b/packages/falter-berlin-tunnelmanager/Makefile
@@ -11,7 +11,7 @@ define Package/falter-berlin-tunnelmanager
   SECTION:=falter-berlin
   CATEGORY:=falter-berlin
   TITLE:=Freifunk Berlin tunnelmanager
-  URL:=http://github.com/Freifunk-Spalter/packages
+  URL:=https://github.com/freifunk-berlin/falter-packages
   EXTRA_DEPENDS:=coreutils-timeout, ip-full, kmod-macvlan, wg-installer-client
   PKGARCH:=all
 endef

--- a/packages/falter-berlin-uhttpd-defaults/Makefile
+++ b/packages/falter-berlin-uhttpd-defaults/Makefile
@@ -9,7 +9,7 @@ define Package/falter-berlin-uhttpd-defaults
   SECTION:=falter-berlin
   CATEGORY:=falter-berlin
   TITLE:=Freifunk Berlin uhttpd default configuration
-  URL:=http://github.com/Freifunk-Spalter/packages
+  URL:=https://github.com/freifunk-berlin/falter-packages
   EXTRA_DEPENDS:=uhttpd, falter-berlin-lib-guard
   PKGARCH:=all
 endef


### PR DESCRIPTION
This pull request replaces all `github.com/Freifunk-Spalter/packages` urls by `github.com/freifunk-berlin/falter-packages`.