### PR TITLE
build: improve UX a little

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -2,7 +2,8 @@
 
 # TODO: generate feeds.conf with revision info
 
-# podman run -i --rm --timeout=1800 --log-driver=none alpine:edge sh -c '( apk add git bash wget xz coreutils build-base gcc abuild binutils ncurses-dev gawk bzip2 perl python3 rsync && git clone https://github.com/freifunk-berlin/falter-packages.git /root/falter-packages && cd /root/falter-packages/ && git checkout master && build/build.sh master x86_64 out/ ) >&2 && cd /root/falter-packages/out/ && tar -c *' > out.tar
+# To run this in a rootless podman container:
+#   podman run -i --rm --timeout=1800 --log-driver=none alpine:edge sh -c '( apk add git bash wget xz coreutils build-base gcc argp-standalone musl-fts-dev musl-obstack-dev musl-libintl abuild binutils ncurses-dev gawk bzip2 perl python3 rsync && git clone https://github.com/freifunk-berlin/falter-packages.git /root/falter-packages && cd /root/falter-packages/ && git checkout master && build/build.sh master x86_64 out/ ) >&2 && cd /root/falter-packages/out/ && tar -c *' > out.tar
 
 set -ex
 set -o pipefail


### PR DESCRIPTION
Maintainer: 
Compile tested: n/a
Run tested: yes

Description:
- build.sh now has a nice help text showing available branch and arch values
- destination argument is now optional, defaults to `./out/<branch>/<arch>`
- documented Podman command has been updated


```
> ./build/build.sh
usage: build/build.sh <branch> <arch> [<destination>]

branch names:
  master  openwrt-22.03  openwrt-21.02

arch names:
  run build/build.sh with a branch name to see available arch names

destination:
  path to a writable directory where the 'falter' feed directory will end up.
  default: ./out/<branch>/<arch>

```
```
> ./build/build.sh foo
usage: build/build.sh <branch> <arch> [<destination>]

branch name:
  foo

arch names:
cat: build/targets-foo.txt: No such file or directory

destination:
  path to a writable directory where the 'falter' feed directory will end up.
  default: ./out/<branch>/<arch>

```
```
> ./build/build.sh master
usage: build/build.sh <branch> <arch> [<destination>]

branch name:
  master

arch names:
  aarch64_cortex-a53  aarch64_cortex-a72  aarch64_generic  arm_arm1176jzf-s_vfp  arm_arm926ej-s  arm_cortex-a15_neon-vfpv4  arm_cortex-a5_vfpv4  arm_cortex-a7  arm_cortex-a7_neon-vfpv4  arm_cortex-a7_vfpv4  arm_cortex-a8_vfpv3  arm_cortex-a9  arm_cortex-a9_neon  arm_cortex-a9_vfpv3-d16  arm_fa526  arm_mpcore  arm_xscale  i386_pentium-mmx  i386_pentium4  mips64_octeonplus  mips_24kc  mips_4kec  mips_mips32  mipsel_24kc  mipsel_24kc_24kf  mipsel_74kc  mipsel_mips32  powerpc_464fp  powerpc_8548  x86_64

destination:
  path to a writable directory where the 'falter' feed directory will end up.
  default: ./out/<branch>/<arch>

```
```
> ./build/build.sh master x86_64
+ dlmirror=https://downloads.openwrt.org
+ mkdir -p ./out/master/x86_64/falter
++ realpath ./out/master/x86_64
+ destdir=/home/user/w/ff/falter-packages/out/master/x86_64
+ sdkdir=./tmp/master/x86_64
...
```