### PR TITLE
packages: fix a few dependencies oopsies

### DIFF
--- a/packages/falter-berlin-migration/Makefile
+++ b/packages/falter-berlin-migration/Makefile
@@ -12,7 +12,6 @@ define Package/falter-berlin-migration
   CATEGORY:=falter-berlin
   TITLE:=Freifunk Berlin configuration migration script
   URL:=https://github.com/freifunk-berlin/falter-packages
-  EXTRA_DEPENDS:=falter-berlin-lib-guard
   PKGARCH:=all
 endef
 

--- a/packages/falter-berlin-uplink-notunnel/Makefile
+++ b/packages/falter-berlin-uplink-notunnel/Makefile
@@ -13,7 +13,7 @@ define Package/falter-berlin-uplink-notunnel
 	CATEGORY:=falter-berlin
 	TITLE:=Freifunk Berlin no tunnel files
 	URL:=http://github.com/freifunk-berlin/packages_berlin
-	EXTRA_DEPENDS:=falter-berlin-lib-guard, kmod-veth, falter-berlin-network-defaults, pingcheck
+	EXTRA_DEPENDS:=kmod-veth, pingcheck
 	PROVIDES:=falter-berlin-uplink
 	PKGARCH:=all
 endef

--- a/packages/falter-berlin-uplink-tunnelberlin/Makefile
+++ b/packages/falter-berlin-uplink-tunnelberlin/Makefile
@@ -12,7 +12,7 @@ define Package/falter-berlin-uplink-tunnelberlin
 	CATEGORY:=falter-berlin
 	TITLE:=Freifunk Berlin Networktunnel files
 	URL:=http://github.com/freifunk-berlin/packages_berlin
-	EXTRA_DEPENDS:=falter-berlin-lib-guard, falter-berlin-tunneldigger, falter-berlin-network-defaults
+	EXTRA_DEPENDS:=falter-berlin-tunneldigger
 	PROVIDES:=falter-berlin-uplink
 	PKGARCH:=all
 endef


### PR DESCRIPTION
Maintainer: 
Compile tested: x86_64
Run tested: x86_64

Description:
Three oopsies that I missed in #384 :-(

These result in the following errors from opkg:
```
Collected errors:
 * pkg_hash_check_unresolved: cannot find dependency falter-berlin-lib-guard for falter-berlin-migration
 * pkg_hash_fetch_best_installation_candidate: Packages for falter-berlin-migration found, but incompatible with the architectures configured
 * opkg_install_cmd: Cannot install package falter-berlin-migration.
 * pkg_hash_check_unresolved: cannot find dependency falter-berlin-lib-guard for falter-berlin-uplink-tunnelberlin
 * pkg_hash_check_unresolved: cannot find dependency falter-berlin-network-defaults for falter-berlin-uplink-tunnelberlin
 * pkg_hash_fetch_best_installation_candidate: Packages for falter-berlin-uplink-tunnelberlin found, but incompatible with the architectures configured
 * opkg_install_cmd: Cannot install package falter-berlin-uplink-tunnelberlin.
```