### PR TITLE
tunnelmanager: fix tunnel endpoint configuration

### DIFF
--- a/packages/falter-berlin-tunnelmanager/files/tunnelmanager.init
+++ b/packages/falter-berlin-tunnelmanager/files/tunnelmanager.init
@@ -7,7 +7,6 @@ STOP=10
 
 tm_start() {
     local instance="$1"
-    local parameters="-T 176.74.57.43 -T 176.74.57.19 -T 77.87.51.11 -T 77.87.49.8"
 
     config_get _value "$instance" namespace
     local namespace="$_value"
@@ -44,9 +43,14 @@ tm_start() {
 
     procd_open_instance
     procd_set_param respawn 3600 5 0
-    procd_set_param command /bin/sh "/usr/bin/tunnelman" "-T 176.74.57.43" "-T" "176.74.57.19" "-T" "77.87.51.11" "-T" "77.87.49.8" "-n" "$namespace" "-m" "$mtu" "-i" "$interface" "-a" "$uplink_ip" "-g" "$uplink_gateway" "-c" "$tunnel_count" "-t" "$tunnel_timeout" "-o" "$check_interval" "-U" "$up_script" "-A" "$up_script_args" "-D" "$down_script"
+    procd_set_param command /bin/sh "/usr/bin/tunnelman"  "-n" "$namespace" "-m" "$mtu" "-i" "$interface" "-a" "$uplink_ip" "-g" "$uplink_gateway" "-c" "$tunnel_count" "-t" "$tunnel_timeout" "-o" "$check_interval" "-U" "$up_script" "-A" "$up_script_args" "-D" "$down_script"
+    config_list_foreach "$instance" tunnel_endpoints append_tunnel_endpoint
     procd_set_param netdev "$interface"
     procd_close_instance
+}
+
+append_tunnel_endpoint() {
+    procd_append_param command "-T" "$1"
 }
 
 wait_for_babeld()

--- a/packages/falter-berlin-tunnelmanager/files/tunnelmanager.init
+++ b/packages/falter-berlin-tunnelmanager/files/tunnelmanager.init
@@ -1,5 +1,15 @@
 #!/bin/sh /etc/rc.common
 
+# Sigh, shellcheck doesn't like comments following its declarations (SC1125),
+# so I'll explain this separately:
+# - SC2034: USE_PROCD, START, STOP appears unused
+# - SC3043: In POSIX sh, 'local' is undefined
+# - SC2154: _value is referenced but not assigned
+
+# shellcheck disable=SC2034
+# shellcheck disable=SC3043
+# shellcheck disable=SC2154
+
 USE_PROCD=1
 
 START=71


### PR DESCRIPTION
Maintainer: @PolynomialDivision 
Compile tested: openwrt-23.05
Run tested: openwrt-23.05 / ipq40xx / fritzbox-4040

Description:
This was a double hardcoding :-)

Tunnel endpoint configuration is helpful for debugging connectivity problems such as freifunk-berlin/bbb-configs#493 