### PR TITLE
packages: clean up uci-defaults, add missing guards

### DIFF
--- a/packages/falter-common/files/etc/uci-defaults/freifunk
+++ b/packages/falter-common/files/etc/uci-defaults/freifunk
@@ -1,3 +1,0 @@
-uci set uhttpd.main.rfc1918_filter=0
-uci commit uhttpd
-

--- a/packages/falter-common/files/etc/uci-defaults/freifunk-berlin-pingcheck-defaults
+++ b/packages/falter-common/files/etc/uci-defaults/freifunk-berlin-pingcheck-defaults
@@ -4,6 +4,9 @@
 
 . /lib/functions.sh
 
+. /lib/functions/guard.sh
+guard "pingcheck"
+
 # remove the sta interface, leaving only wan
 uci del pingcheck.@interface\[1\]
 

--- a/packages/falter-common/files/etc/uci-defaults/freifunk-berlin-uhttpd-defaults
+++ b/packages/falter-common/files/etc/uci-defaults/freifunk-berlin-uhttpd-defaults
@@ -11,6 +11,12 @@ guard "uhttpd"
 uci set uhttpd.px5g.commonname="Freifunk Berlin - $(dd if=/dev/urandom bs=4 count=1 | hexdump -e '1/1 "%02x"')"
 # do force redirect to https for encrypted web interface
 uci set uhttpd.main.redirect_https=1
+
+# Disable filtering requests from RFC1918 IP addresses.
+# This is a DNS rebinding countermeasure that we don't want,
+# since we use the 10.0.0.0/8 space for OLSR meshing.
+uci set uhttpd.main.rfc1918_filter=0
+
 uci commit
 
 service uhttpd reload

--- a/packages/falter-common/files/etc/uci-defaults/freifunk-berlin-wireless-defaults
+++ b/packages/falter-common/files/etc/uci-defaults/freifunk-berlin-wireless-defaults
@@ -12,6 +12,9 @@
 . /lib/config/uci.sh
 . /lib/functions/system.sh
 
+. /lib/functions/guard.sh
+guard "wireless"
+
 mac_addr=$(get_mac_label | cut -c 10-)
 
 if [ -z "$mac_addr" ]; then

--- a/packages/falter-common/files/etc/uci-defaults/freifunk-olsrv1
+++ b/packages/falter-common/files/etc/uci-defaults/freifunk-olsrv1
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-uci -m import freifunk <<EOF
-config 'defaults' 'olsr_interfacedefaults'
-	option 'Ip4Broadcast' '255.255.255.255'
-EOF


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
- Remove redundant freifunk-olsrv1 script
- Remove freifunk script, move its contents to uhttpd
- Add guards for network, pingcheck, wireless

Now that most uci-defaults script have moved into the falter-common package, bbb-configs needs to be able to disable all of them. That's what the added guards are for.