### PR TITLE
tunnelmanager: allow used keys to time out on servers

### DIFF
--- a/packages/falter-berlin-tunnelmanager/files/tunnelman.sh
+++ b/packages/falter-berlin-tunnelmanager/files/tunnelman.sh
@@ -210,6 +210,9 @@ manage() {
                 fi
             else
                 log "No servers available..."
+                log "Backing down for 500 + 60 = 610 seconds so keys could time out on servers..."
+                sleep 550 &
+                wait $!
                 break
             fi
         done


### PR DESCRIPTION
This introduces an additional delay which allows for used keys to time out on the servers. Without this tunnelmanager could end up in an endless loop where it keeps the keys in a used state and never completes to establish a tunnel.
