### PR TITLE
tunnelmanager: fix adding interfaces by reloading again

### DIFF
--- a/packages/falter-berlin-tunnelmanager/files/up.sh
+++ b/packages/falter-berlin-tunnelmanager/files/up.sh
@@ -140,12 +140,15 @@ if [ $? -eq 1 ]; then
     # no olsr running start
     /etc/init.d/olsrd start
 else
+    /etc/init.d/olsrd reload
     # instead of reloading add interface via ipc to make it seamless
-    if [[ ! -z "$lqm" ]]; then
-        ubus call olsrd add_interface '{"ifname":'\""$interface"\"',"lqm":'\""$lqm"\"'}'
-    else
-        ubus call olsrd add_interface '{"ifname":'\""$interface"\"'}'
-    fi
+    # note: we tried this, however it does not work reliably, therefore we are back to
+    # reloading olsrd instead. we leave the ipc code so it could be improved
+    # if [[ ! -z "$lqm" ]]; then
+    #     ubus call olsrd add_interface '{"ifname":'\""$interface"\"',"lqm":'\""$lqm"\"'}'
+    # else
+    #     ubus call olsrd add_interface '{"ifname":'\""$interface"\"'}'
+    # fi
 fi
 
 # Configure babeld
@@ -171,9 +174,12 @@ ubus list | grep -qF babeld
 if [ $? -eq 1 ]; then
     /etc/init.d/babeld start
 else
+    /etc/init.d/babeld reload
     # instead of reloading add interface via ipc to make it seamless
-    ubus call babeld add_interface '{"ifname":'\""$interface"\"'}'
-    if [[ ! -z "$metric" ]]; then
-        ubus call babeld add_filter '{"ifname":'\""$interface"\"',"type":0,"metric":'$metric'}'
-    fi
+    # note: we tried this, however it does not work reliably, therefore we are back to
+    # reloading babeld instead. we leave the ipc code so it could be improved
+    # ubus call babeld add_interface '{"ifname":'\""$interface"\"'}'
+    # if [[ ! -z "$metric" ]]; then
+    #     ubus call babeld add_filter '{"ifname":'\""$interface"\"',"type":0,"metric":'$metric'}'
+    # fi
 fi


### PR DESCRIPTION
After creating new tunnels the ipc calls are often unreliably and olsrd even crashes in combination with using ipc, which results in unconfigured interfaces. The problem is that the current ipc code simply does not have any error handling to deal with failed calls. This change switches back to reloading olsrd and babeld to make tunnels more reliably in order to prevent nodes from getting isolated, but reintroduces the issue of loosing routes when doing a reload. A solution to this is pointed out here: https://github.com/freifunk-berlin/falter-packages/issues/401#issuecomment-1689911339

For reference a log that shows olsrd crashing with ipc.

```
Mon Sep 11 15:19:38 2023 user.notice tunnelman: Server handling least clients is: 77.87.51.131. Trying to create tunnel...
Mon Sep 11 15:19:40 2023 user.notice wg-client-installer: Registered: wg_51820
Mon Sep 11 15:19:40 2023 user.notice tunnelman: New tunnel interface is wg_51820
Mon Sep 11 15:19:43 2023 daemon.err babeld[13372]: ioctl(SIOCGIWNAME): Not a tty
Mon Sep 11 15:19:43 2023 daemon.err babeld[13372]: Warning: couldn't determine whether wg_51820 (38) is a wireless interface.
Mon Sep 11 15:19:44 2023 daemon.info olsrd[12887]: Writing '0' (was 0) to /proc/sys/net/ipv4/conf/wg_51820/send_redirects
Mon Sep 11 15:19:44 2023 daemon.info olsrd[12887]: Writing '0' (was 0) to /proc/sys/net/ipv4/conf/wg_51820/rp_filter
Mon Sep 11 15:19:44 2023 daemon.info olsrd[12887]: Adding interface wg_51820
Mon Sep 11 15:19:45 2023 daemon.err olsrd[12887]: crash (logging a stack trace is not supported on this platform)
Mon Sep 11 15:19:46 2023 daemon.info olsrd[12887]: Writing '1' (was 0) to /proc/sys/net/ipv4/conf/switch0.30/send_redirects
Mon Sep 11 15:19:46 2023 daemon.info olsrd[12887]: Writing '1' (was 0) to /proc/sys/net/ipv4/conf/switch0.21/send_redirects
Mon Sep 11 15:19:46 2023 daemon.info olsrd[12887]: Writing '1' (was 0) to /proc/sys/net/ipv4/conf/switch0.20/send_redirects
Mon Sep 11 15:19:46 2023 daemon.info olsrd[12887]: Writing '1' (was 0) to /proc/sys/net/ipv4/conf/switch0.11/send_redirects
Mon Sep 11 15:19:46 2023 daemon.info olsrd[12887]: olsr.org - pre-0.9.9-git_0000000-hash_5ccaf6c8b903022374ea8a44065e0940 stopped
```

