### PR TITLE
build: make it easier to build against local mirrors

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2015
+
 # TODO: generate feeds.conf with revision info
 # TODO: use $dlmirror for repositories.conf as well
 
@@ -8,6 +10,8 @@
 
 function usage() {
   local br="$1"
+  local arch=""
+
   echo "usage: build/build.sh <branch> <arch> [<destination>]"
   echo
   if [ -n "$br" ]; then
@@ -15,8 +19,9 @@ function usage() {
     echo "  $br"
     echo
     echo "arch names:"
-    for a in $(cat "build/targets-$br.txt" | grep -v '#' | grep . | cut -d' ' -f1); do
-      echo -n "  $a"
+    (grep -v '#' | grep . | cut -d' ' -f1) < "build/targets-$br.txt" | while IFS= read -r arch
+    do
+      echo -n "  $arch"
     done
     echo
   else
@@ -34,6 +39,7 @@ function usage() {
   exit 1
 }
 
+# shell check SC2015: If-then-else work here, as a assignment can not fail.
 [ -n "$1" ] && branch="$1" || usage >&2
 [ -n "$2" ] && arch="$2" || usage "$branch" >&2
 [ -n "$3" ] && dest="$3" || dest="./out/$branch/$arch"
@@ -72,7 +78,7 @@ unbuf="stdbuf --output=0 --error=0"
   [ "$branch" == "openwrt-21.02" ] && dlurl="$dlmirror/releases/21.02-SNAPSHOT/targets"
 
   # determine the sdk tarball's filename
-  target=$(cat "./build/targets-$branch.txt" | grep -v '#' | grep -F "$arch " | cut -d ' ' -f 2)
+  target=$( (grep -v '#' | grep -F "$arch " | cut -d ' ' -f 2) < "./build/targets-$branch.txt")
   sdkfile=$(wget -q -O - "$dlurl/$target/sha256sums" | cut -d '*' -f 2 | grep -i openwrt-sdk-)
 
   # download and extract sdk tarball

--- a/build/build.sh
+++ b/build/build.sh
@@ -42,8 +42,21 @@ set -o pipefail
 set -e
 set -x
 
+# Mirror base URL for SDK download.
+# We search in $dlmirror/releases/$version-SNAPSHOT/targets/sha256sum.
 dlmirror="https://downloads.openwrt.org"
-#dlmirror="file:///mnt/mirror/downloads.openwrt.org"
+# dlmirror="file:///mnt/mirror/downloads.openwrt.org"
+# dlmirror="http://192.168.1.1/downloads.openwrt.org"
+
+# Mirror URL for source tarball downloads.
+srcmirror="https://sources.openwrt.org;https://firmware.berlin.freifunk.net/sources"
+# srcmirror="file:///mnt/mirror/sources.openwrt.org;file:///mnt/mirror/firmware.berlin.freifunk.net/sources"
+# srcmirror="http://192.168.1.1/sources.openwrt.org;http://192.168.1.1/firmware.berlin.freifunk.net/sources"
+
+# Mirror URL for Git repositories in feeds.conf
+gitmirror="https://git.openwrt.org"
+# gitmirror="file:///mnt/mirror/git.openwrt.org"
+# gitmirror="http://192.168.1.1/git.openwrt.org"
 
 mkdir -p "$dest/falter"
 destdir=$(realpath "$dest")
@@ -74,6 +87,12 @@ unbuf="stdbuf --output=0 --error=0"
   ln -sfT "$(pwd)/packages" ./tmp/feed/packages
   ln -sfT "$(pwd)/luci" ./tmp/feed/luci
   cp "$sdkdir/feeds.conf.default" "$sdkdir/feeds.conf"
+  if [ "$gitmirror" != "https://git.openwrt.org" ]; then
+    sed -i "s|https://git.openwrt.org/openwrt|$gitmirror|g" "$sdkdir/feeds.conf"
+    sed -i "s|https://git.openwrt.org/feed|$gitmirror|g" "$sdkdir/feeds.conf"
+    sed -i "s|https://git.openwrt.org/project|$gitmirror|g" "$sdkdir/feeds.conf"
+    sed -i 's|src-git |src-git-full |g' "$sdkdir/feeds.conf"
+  fi
   echo "src-link falter $(pwd)/tmp/feed" >> "$sdkdir/feeds.conf"
 
   cd "$sdkdir"
@@ -83,6 +102,7 @@ unbuf="stdbuf --output=0 --error=0"
   make defconfig
   ./scripts/feeds update -a
   ./scripts/feeds install -a -p falter
+  export DOWNLOAD_MIRROR="$srcmirror"
   for p in $(find -L feeds/falter -name Makefile | awk -F/ '{print $(NF - 1)}'); do
     make -j8 V=s "package/$p/compile"
   done

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # TODO: generate feeds.conf with revision info
+# TODO: use $dlmirror for repositories.conf as well
 
 # To run this in a rootless podman container:
 #   podman run -i --rm --timeout=1800 --log-driver=none alpine:edge sh -c '( apk add git bash wget xz coreutils build-base gcc argp-standalone musl-fts-dev musl-obstack-dev musl-libintl abuild binutils ncurses-dev gawk bzip2 perl python3 rsync && git clone https://github.com/freifunk-berlin/falter-packages.git /root/falter-packages && cd /root/falter-packages/ && git checkout master && build/build.sh master x86_64 out/ ) >&2 && cd /root/falter-packages/out/ && tar -c *' > out.tar
@@ -53,20 +54,20 @@ sdkdir="./tmp/$branch/$arch"
 unbuf="stdbuf --output=0 --error=0"
 (
   # pick the right URL
-  dldir="snapshots"
-  [ "$branch" == "openwrt-22.03" ] && dldir="releases/22.03-SNAPSHOT"
-  [ "$branch" == "openwrt-21.02" ] && dldir="releases/21.02-SNAPSHOT"
+  dlurl="$dlmirror/snapshots/targets"
+  [ "$branch" == "openwrt-22.03" ] && dlurl="$dlmirror/releases/22.03-SNAPSHOT/targets"
+  [ "$branch" == "openwrt-21.02" ] && dlurl="$dlmirror/releases/21.02-SNAPSHOT/targets"
 
   # determine the sdk tarball's filename
   target=$(cat "./build/targets-$branch.txt" | grep -v '#' | grep -F "$arch " | cut -d ' ' -f 2)
-  sdk=$(wget -q -O - "$dlmirror/$dldir/targets/$target/sha256sums" | cut -d '*' -f 2 | grep -i openwrt-sdk-)
+  sdkfile=$(wget -q -O - "$dlurl/$target/sha256sums" | cut -d '*' -f 2 | grep -i openwrt-sdk-)
 
   # download and extract sdk tarball
   mkdir -p "./tmp/dl/$branch"
-  wget --progress=dot:giga -O "./tmp/dl/$branch/$sdk" "$dlmirror/$dldir/targets/$target/$sdk"
+  wget --progress=dot:giga -O "./tmp/dl/$branch/$sdkfile" "$dlurl/$target/$sdkfile"
   rm -rf "$sdkdir"
   mkdir -p "$sdkdir"
-  tar -x -C "$sdkdir" --strip-components=1 -f "./tmp/dl/$branch/$sdk"
+  tar -x -C "$sdkdir" --strip-components=1 -f "./tmp/dl/$branch/$sdkfile"
 
   # configure our feed, with an indirection via /tmp/feed so sdk doesn't recurse our feed
   mkdir -p ./tmp/feed


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64
Run tested: n/a

Description:
When we have mirrors running in the mesh, we can make the mirror URLs actual command options. The commented examples are helpful enough for now.