### PR TITLE
falter-berlin-autoupdate: Add validators to input fields

### DIFF
--- a/luci/luci-app-falter-autoupdate/htdocs/luci-static/resources/view/falter-autoupdate/form.js
+++ b/luci/luci-app-falter-autoupdate/htdocs/luci-static/resources/view/falter-autoupdate/form.js
@@ -4,7 +4,7 @@
 
 return view.extend({
   render: function () {
-    var m, s, o;
+    var m, s, o1, o2, o3, o4;
 
     m = new form.Map('autoupdate', _('Freifunk Berlin Autoupdate'),
       _("Autoupdate will update your router automatically, once there is a new\
@@ -20,18 +20,21 @@ return view.extend({
     s = m.section(form.TypedSection, 'generic', _('Settings'));
     s.anonymous = true;
 
-    s.option(form.Value, 'selector_fqdn', _('Selector-FQDN'),
+    o1 = s.option(form.Value, 'selector_fqdn', _('Selector-FQDN'),
       _('URL of the firmware-selector without protocol. Usally: selector.berlin.freifunk.net'));
+    o1.datatype = 'hostname';
 
-    s.option(form.Value, 'fw_server_fqdn', _('Firmware-Server-FQDN'),
+    o2 = s.option(form.Value, 'fw_server_fqdn', _('Firmware-Server-FQDN'),
       _('URL of the firmware server without protocol. Usally firmware.berlin.freifunk.net'));
+    o2.datatype = 'hostname';
 
-    s.option(form.Value, 'minimum_certs', _('Minimum Certs'),
+    o3 = s.option(form.Value, 'minimum_certs', _('Minimum Certs'),
       _('Minimum amount of certificates that must be valid. Otherwise autoupdate will not perform an upgrade.'));
+    o3.datatype = 'uinteger';
 
-    o = s.option(form.Flag, 'disabled', _('Disabled'),
+    o4 = s.option(form.Flag, 'disabled', _('Disabled'),
       _('Deactivates the Autoupdater. We do not recommend this!'));
-    o.rmempty = false;
+    o4.rmempty = false;
 
     return m.render();
   }


### PR DESCRIPTION
Adds validator to the input fileds of the autoupdate luci app. Runtested on my falter router at home.
