### PR TITLE
falter-berlin-autoupdate: Add custom-config detection

### DIFF
--- a/luci/luci-app-falter-autoupdate/htdocs/luci-static/resources/view/falter-autoupdate/form.js
+++ b/luci/luci-app-falter-autoupdate/htdocs/luci-static/resources/view/falter-autoupdate/form.js
@@ -4,7 +4,9 @@
 
 return view.extend({
   render: function () {
-    var m, s, o1, o2, o3, o4;
+    var m, s, t, o1, o2, o3, o4, o5;
+
+    addNotification('Warnasdfads', )
 
     m = new form.Map('autoupdate', _('Freifunk Berlin Autoupdate'),
       _("Autoupdate will update your router automatically, once there is a new\
@@ -35,6 +37,14 @@ return view.extend({
     o4 = s.option(form.Flag, 'disabled', _('Disabled'),
       _('Deactivates the Autoupdater. We do not recommend this!'));
     o4.rmempty = false;
+
+    o5 = s.option(form.Flag, 'ignore_mod', _('Ignore config changes'),
+    _("The autoupdater will detect custom changes you've applied to your router since you've run the wizard.\
+       It will refuse an autoupdate then, to avoid breaking your customized setup. If you wish to automatically\
+       update anyway, activate this option. We do not recommend this, as this might break your setup on auto-updates."));
+
+
+    // t = m.section(form.TypedSection, 'autoupdatehints', _())
 
     return m.render();
   }

--- a/packages/falter-berlin-autoupdate/Makefile
+++ b/packages/falter-berlin-autoupdate/Makefile
@@ -59,6 +59,7 @@ define Package/falter-berlin-autoupdate/install
 	$(CP) ./files/lib_autoupdate.sh $(1)/lib/autoupdate/lib_autoupdate.sh
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(CP) ./files/post-inst.sh $(1)/etc/uci-defaults/90_autoupdate-post-inst.sh
+	$(CP) ./files/zz-autoupdate_diff.sh $(1)/etc/uci-defaults/zz-autoupdate_diff.sh
 endef
 
 define Package/falter-berlin-autoupdate-keys/install

--- a/packages/falter-berlin-autoupdate/files/autoupdate.conf
+++ b/packages/falter-berlin-autoupdate/files/autoupdate.conf
@@ -4,5 +4,7 @@ config generic cfg
         option minimum_certs    3
         option disabled         0
         option ignore_mod       0
+
+config autoupdatehints cfh
         option mod_warning      0
         option no_autou_avail   0

--- a/packages/falter-berlin-autoupdate/files/autoupdate.conf
+++ b/packages/falter-berlin-autoupdate/files/autoupdate.conf
@@ -3,3 +3,6 @@ config generic cfg
         option selector_fqdn    'selector.berlin.freifunk.net'
         option minimum_certs    3
         option disabled         0
+        option ignore_mod       0
+        option mod_warning      0
+        option no_autou_avail   0

--- a/packages/falter-berlin-autoupdate/files/autoupdate.sh
+++ b/packages/falter-berlin-autoupdate/files/autoupdate.sh
@@ -144,7 +144,7 @@ rm -rf "$PATH_DIR"
 mkdir -p "$PATH_DIR"
 
 log "fetch autoupdate.json from $FW_SERVER_URL ..."
-if load_overview_and_certs "$FW_SERVER_URL"; then
+if ! load_overview_and_certs "$FW_SERVER_URL"; then
     log "fetching autoupdate.json failed. Probably no internet connection."
     exit 2
 fi
@@ -165,7 +165,7 @@ else
     log "ignoring certificates as requested."
 fi
 
-if latest_release=$(read_latest_stable "$PATH_DIR/autoupdate.json"); then
+if ! latest_release=$(read_latest_stable "$PATH_DIR/autoupdate.json"); then
     log "wasn't able to read latest stable version from autoupdate.json"
     exit 2
 else

--- a/packages/falter-berlin-autoupdate/files/autoupdate.sh
+++ b/packages/falter-berlin-autoupdate/files/autoupdate.sh
@@ -172,6 +172,24 @@ else
     log "latest release is $latest_release"
 fi
 
+if [ -z "$OPT_FORCE" ]; then
+    detect_custom_config "/etc/autoupdate/cheksums"
+    retval=$?
+    if [ $retval = 2 ]; then
+        log "You customized the configuration of your system since the first wizard run."
+        log "This can lead to incompabilities in the update process. Please consider"
+        log "updating manually."
+        exit 2
+    elif [ $retval = 1 ]; then
+        log "There were no checksums of your config files, to compare with. We were not"
+        log "able to detect, wether your config is customized. Please consider updating"
+        log "manually."
+        exit 2
+    else
+        log "Config wasn't modified since wizard run".
+    fi
+fi
+
 ##################
 #  Update-stuff
 

--- a/packages/falter-berlin-autoupdate/files/zz-autoupdate_diff.sh
+++ b/packages/falter-berlin-autoupdate/files/zz-autoupdate_diff.sh
@@ -1,0 +1,28 @@
+#!/bin/ash
+
+# After everything on the router was configured, this script gets run for gene-
+# rating checksums of all config files. Autoupdate uses this, to detect custom
+# setups and refuse an automatic update then. This can be overirdden in user
+# settings.
+
+# filenames will not contain spaces. Thus keeping the for-loop simple for
+# better maintainability
+# shellcheck disable=SC2044
+
+# don't run ssid_changer, if the wizard wasn't run yet.
+if [ ! -f /etc/config/ffwizard ]; then
+    log "ffwizard didn't run yet. Cancelling scripts run."
+    exit 1
+fi
+
+watch_dirs="/etc/config/"
+chksum_dir="/etc/autoupdate/cheksums"
+
+for dir in $watch_dirs; do
+    mkdir -p "$chksum_dir""$dir"
+    # filename will not contain spaces.
+    for file in $(find "$dir" -type f); do
+        md5=$(md5sum "$file" | cut -d' ' -f 1)
+        echo "$md5" > "$chksum_dir""$file"
+    done
+done


### PR DESCRIPTION
Kompiliert Ja/Nein: (Bitte gib Prozessorarchitektur, Modell und Falter/OpenWrtversion an)
Läuft live Ja/Nein: (Bitte gib Prozessorarchitektur, Modell und Falter/OpenWrtversion an und wie du deine Änderungen getestet hast)

Beschreibung deiner Änderungen:

----------

Compile tested: no
Run tested: yes, on falter 1.2.3


When updating nodes automatically, we want to detect custom changes made by the user. As nodes may brake when using non-standard config and updating, we want to avoid updating on these nodes.
