### PR TITLE
tunspace: bunch of improvements

### DIFF
--- a/packages/tunspace/tunspace.defaults
+++ b/packages/tunspace/tunspace.defaults
@@ -7,6 +7,7 @@ package 'tunspace'
 config tunspace "tunspace"
   option uplink_netns "uplink"
   option uplink_ifname "br-wan"
+  option uplink_mode "bridge"
   option maintenance_interval 15
   option debug 0
 

--- a/packages/tunspace/tunspace.defaults
+++ b/packages/tunspace/tunspace.defaults
@@ -46,7 +46,6 @@ config wg-interface
   option ipv4 "10.31.174.138/32"
   option mtu 1280
   option port 51820
-  option keyfile "/etc/tunspace/ts_wg0.key"
   option disabled 0
 
 EOT

--- a/packages/tunspace/tunspace.init
+++ b/packages/tunspace/tunspace.init
@@ -23,7 +23,6 @@ boot() {
 
 start_service() {
   config_load tunspace
-  config_foreach gen_wg_key "wg-interface"
 
   procd_open_instance
   procd_set_param command /usr/bin/tunspace
@@ -34,20 +33,6 @@ stop_service() {
   config_load tunspace
   config_foreach del_wg_iface "wg-interface"
   del_uplink_netns
-}
-
-gen_wg_key() {
-  local section="$1"
-  local _value keyfile
-  config_get keyfile "$section" keyfile
-  test -n "$keyfile" || return # path is empty, skip
-  test -s "$keyfile" && return # keyfile exists, skip
-  mkdir -p "$(dirname "$keyfile")"
-
-  config_get _value "$section" ifname
-  logger -t tunspace "generating private key for $_value, this could take a while..."
-  head -c32 /dev/random | ucode -lfs -p 'b64enc(fs.stdin.read("all"));' > "$keyfile"
-  logger -t tunspace "finished generating key for $_value"
 }
 
 del_wg_iface() {

--- a/packages/tunspace/tunspace.uc
+++ b/packages/tunspace/tunspace.uc
@@ -40,6 +40,7 @@ function load_config(name) {
     "debug": int(ts.debug) != 0,
     "uplink_netns": ""+ts.uplink_netns,
     "uplink_ifname": ""+ts.uplink_ifname,
+    "uplink_mode": ""+ts.uplink_mode,
     "maintenance_interval": int(ts.maintenance_interval),
     "wireguard_servers": {},
     "wireguard_interfaces": {},
@@ -393,31 +394,36 @@ function wireguard_maintenance(st, cfg) {
 }
 
 // TODO: ts_uplink interface leaks into default namespace when uplink namespace is deleted
-function uplink_maintenance(nsid, netns, ifname) {
+function uplink_maintenance(nsid, netns, ifname, mode) {
   let netnsifname = UPLINK_NETNS_IFNAME;
 
-  if (interface_exists_netns(netnsifname, netns)) {
-    // try dhcp for 5 seconds
-    shell_command("ip netns exec "+netns+" udhcpc -f -n -q -A 5 -i "+netnsifname+" -s /usr/share/tunspace/udhcpc.script 2>&1 | grep 'ip addr add'");
-  } else {
-    if (!interface_exists(ifname)) {
-      log(sprintf("missing uplink interface %s", ifname));
-      return false;
-    } else {
-      // move uplink interface directly:
-      // shell_command("ip link set dev "+ifname+" netns "+netns);
-      // shell_command("ip -n "+netns+" link set "+ifname+" up");
-      // shell_command("ip -n "+netns+" link set "+ifname+" name "+netnsifname);
-
-      // or create a macvlan bridge:
-      shell_command("ip link add "+netnsifname+" link "+ifname+" type macvlan mode bridge");
-      shell_command("ip link set dev "+netnsifname+" netns "+netns);
-      shell_command("ip -n "+netns+" link set up "+netnsifname+"");
-
-      // try dhcp for 5 seconds
-      shell_command("ip netns exec "+netns+" udhcpc -f -n -q -A 5 -i "+netnsifname+" -s /usr/share/tunspace/udhcpc.script 2>&1 | grep 'ip addr add'");
-    }
+  if (interface_exists(netnsifname)) {
+    // the uplink interface will sometimes leak out of the namespace on shutdown
+    shell_command("ip link set "+netnsifname+" netns "+netns);
   }
+
+  if (interface_exists_netns(netnsifname, netns)) {
+    shell_command("ip -n "+netns+" link set "+netnsifname+" up");
+  } else if (!interface_exists(ifname)) {
+    log(sprintf("missing uplink interface %s", ifname));
+    return false;
+  } else if (mode == "direct") {
+    // move uplink interface directly:
+    shell_command("ip link set dev "+ifname+" netns "+netns);
+    shell_command("ip -n "+netns+" link set "+ifname+" name "+netnsifname);
+    shell_command("ip -n "+netns+" link set "+netnsifname+" up");
+  } else if (mode == "bridge") {
+    // or create a macvlan bridge:
+    shell_command("ip link add "+netnsifname+" link "+ifname+" type macvlan mode bridge");
+    shell_command("ip link set dev "+netnsifname+" netns "+netns);
+    shell_command("ip -n "+netns+" link set up "+netnsifname+"");
+  } else {
+    log(sprintf("uplink mode must be 'bridge' or 'direct', got '%s'", mode));
+    return false;
+  }
+
+  // try dhcp for 5 seconds
+  shell_command("ip netns exec "+netns+" udhcpc -f -n -q -A 5 -i "+netnsifname+" -s /usr/share/tunspace/udhcpc.script 2>&1 | grep 'ip addr add'");
 
   return true;
 }
@@ -444,7 +450,7 @@ function boot(st, cfg) {
 function tick(st, cfg) {
   debug("tick");
 
-  if (!uplink_maintenance(st.nsid, cfg.uplink_netns, cfg.uplink_ifname)) {
+  if (!uplink_maintenance(st.nsid, cfg.uplink_netns, cfg.uplink_ifname, cfg.uplink_mode)) {
     log("uplink maintenance failed");
   }
   wireguard_maintenance(st, cfg);


### PR DESCRIPTION
Compile tested: ipq40xx, ath79
Run tested: Fritzbox 4040, Glinet GL-XE300

Description of your changes:

These changes came about while setting up the XE300's internal LTE modem.

- Handling of the uplink interface in various difficult situations is now much more robust, it recovers more reliably, etc.
- Some types of uplink interfaces can't be added to a bridge, for various reasons. We now support a "direct" uplink mode which doesn't clone a macvlan bridge interface, and instead moves the uplink interface itself directly to the namespace.
  - The downside of this mode is that the fully configured and functional uplink interface will definitely leak out of the namespace on tunspace restart or stop.
- The wg-installer servers on each gateway have a timeout based on a client's private key, which rejects reconnections (as in: re-registration) for 10 minutes or so. This can easily lead to situations where all available servers reject our private key for an annoyingly long time.
  - The tunspace client now generates a fresh new private key whenever it registers with a server. This circumvents the re-registration timeout, and there's also really no need for the wireguard keys to be permanent.