### PR TITLE
falter-berlin-autoupdate: if possible, use --ignore-minor-compat-version

### DIFF
--- a/packages/falter-berlin-autoupdate/files/autoupdate.sh
+++ b/packages/falter-berlin-autoupdate/files/autoupdate.sh
@@ -240,7 +240,13 @@ if semverLT "$FREIFUNK_RELEASE" "$latest_release"; then
         if [ -n "$OPT_N" ]; then
             sysupgrade -n "$PATH_BIN"
         else
-            sysupgrade "$PATH_BIN"
+            check_ignore_minor_compat
+            ret_code=$?
+            if [ $ret_code = 0 ]; then
+                sysupgrade --ignore-minor-compat-version "$PATH_BIN"
+            else
+                sysupgrade "$PATH_BIN"
+            fi
         fi
         log "done."
     fi

--- a/packages/falter-berlin-autoupdate/files/lib_autoupdate.sh
+++ b/packages/falter-berlin-autoupdate/files/lib_autoupdate.sh
@@ -246,3 +246,14 @@ min_valid_certificates() {
 
     return $cert_cnt
 }
+
+check_ignore_minor_compat() {
+    # checks if the installed sysupgrade tool supports the option
+    # --ignore-minor-compat-version already.
+    # returns 0 if option is available, 1 otherwise
+    if sysupgrade -h | grep -q 'ignore-minor-compat-version'; then
+        return 0
+    else
+        return 1
+    fi
+}


### PR DESCRIPTION
The option `--ignore-minor-compat-version` enables the sysupgrade command to do an update also in case, there is a minor compat-version upgrade. This is relevant for the change from swconfig to dsa.


Compile tested: no.
Run tested: Yes, on a Archer-C5v1 w/ Falter 1.2.3 (OpenWrt-21.02) and mikrotik_routerboard-750gr3 w/ OpenWrt-23.05