### PR TITLE
tunspace: avoid exhausting uplink's DHCP IP pool

### DIFF
--- a/packages/tunspace/tunspace.uc
+++ b/packages/tunspace/tunspace.uc
@@ -105,6 +105,7 @@ function shell_command(cmd) {
 function create_namespace(st, nsname) {
   let p = fs.popen("ip -j netns list-id", "r");
   let out = p.read("all");
+  p.close();
   debug("ip -j netns list-id (error="+p.error()+")");
   if (out == null) {
     return false;


### PR DESCRIPTION
Compile tested: yes snapshot
Run tested: x86/64 snapshot

Description of your changes:

Our DHCP requests to the uplink DHCP server don't specify an existing IP address that we might already have. Most DHCP servers will notice that and give us the existing IP adress. A few DHCP servers will give us a fresh new different IP address for every maintenance tick, and quickly exhaust their IP pool depending on the leasetime.

I'm too lazy to completely handle leasetimes, so a good middleground is to tell the DHCP server that we already have an address and would like to renew it.

It looks like this in action:
```
tick
rtnl: cmd=18 flags=1 msg={ "ifname": "ts_uplink" } error=null reply=bool
ip -n uplink link show ts_uplink >/dev/null 2>/dev/null (exit=0)
ip -n uplink link set ts_uplink up (exit=0)
udhcpc: ip addr add 192.168.177.26/255.255.255.0 broadcast 192.168.177.255 dev ts_uplink
ip netns exec uplink udhcpc -f -n -q -A 5 -i ts_uplink -r 192.168.177.26 -s /usr/share/tunspace/udhcpc.script 2>&1 | grep 'ip addr add' (exit=0)
[... wireguard maintenance ...]
tick end
```