### PR TITLE
[23.05] bird2-babelpatch: fix unaligned access on ARMv7 targets

### DIFF
--- a/packages/bird2-babelpatch/Makefile
+++ b/packages/bird2-babelpatch/Makefile
@@ -57,6 +57,10 @@ This is the 2.0 branch of Bird which integrates support for IPv4 and IPv6
 into a single branch, and also adds support for the Babel routing protocol.
 endef
 
+ifeq ($(ARCH),arm)
+TARGET_CFLAGS+=-mno-unaligned-access
+endif
+
 CONFIGURE_ARGS += --disable-libssh
 
 define Package/bird2/conffiles


### PR DESCRIPTION
An assembler instruction "vst1.8 {d16-d17}, [r0 :64]" requires `r0` to be 64-bit (8-byte) aligned. However, in certain cases, `r0` was not aligned, leading to a SIGBUS error on ARMv7 platforms:

    kern.err kernel: [90636.175853] Alignment trap: not handling
    instruction f4400a1f at [<00056fbc>]
    kern.alert kernel: [90636.182044] Unhandled fault: alignment
    exception (0x801) at 0xb6dec01c

A backtrace shows the crash occurring in `bgp_get_prefix` due to the misaligned memory address.

Fix this issue by passing the `-mno-unaligned-access` flag to GCC/Clang. This ensures unaligned accesses are avoided on platforms like ARMv7, preventing alignment-related exceptions and ensuring reliable execution.

(cherry picked from commit fcce390fc57b44593fe969f1063c6ba711fc7f9b)
