### PR TITLE
tunspace: handle http endpoint quirks, fix respawn behavior

### DIFF
--- a/packages/tunspace/tunspace.init
+++ b/packages/tunspace/tunspace.init
@@ -26,6 +26,7 @@ start_service() {
 
   procd_open_instance
   procd_set_param command /usr/bin/tunspace
+  procd_set_param respawn 60 10 0  # respawn indefinitely, wait 10s before retry
   procd_close_instance
 }
 

--- a/packages/tunspace/tunspace.uc
+++ b/packages/tunspace/tunspace.uc
@@ -324,7 +324,7 @@ function wg_replace_endpoint(ifname, cfg, url) {
     debug(sprintf(cmd+" (error=%s)", "...", p.error()));
   }
   let reply = json(out);
-  if (reply.result[0] != 0 || reply.result[1].response_code != 0) {
+  if (!reply.result || reply.result[0] != 0 || reply.result[1].response_code != 0) {
     // response_code 1 means "public key is already used"
     // see wg-installer/wg-server/lib/wg_functions.sh
     log(sprintf(cmd+" (error=unexpected content, data=%s)", "...", out));


### PR DESCRIPTION
Compile tested: x86_64 snapshot
Run tested: x86_64 snapshot bbb-configs

Description of your changes:

We currently don't have the wireguard server (wg-installer-server) installed on ak36-gw and strom-gw. This exposes two bugs in tunspace:

1. It doesn't properly deal with the wireguard server host and http server being available, while the specific wg-installer-server http endpoint is missing. Instead it just crashes.
2. The procd service script doesn't set custom respawn options, and the defaults would only respawn after an hour.