### PR TITLE
bgpdisco: fixup advertisement of static routes

### DIFF
--- a/packages/bgpdisco/Makefile
+++ b/packages/bgpdisco/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bgpdisco
-PKG_VERSION:=1
+PKG_VERSION:=1.1
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Simon Polack <spolack+git@mailbox.org>

--- a/packages/bgpdisco/bird_config_template.ut
+++ b/packages/bgpdisco/bird_config_template.ut
@@ -18,6 +18,11 @@ protocol static static_bgpdisco_v6 {
 {% endif; endfor %}
 }
 
+filter bgpdisco_export_v6 {
+	bgp_next_hop = 2001:db8::;
+	accept;
+}
+
 {% let i = 0; %}
 {% for (let neigh in neighbors): %}
 protocol bgp bgpdisco_{{ i++ }}_{{ replace(replace(neigh.iface, '.', '_'), '-', '_') }} {
@@ -37,9 +42,8 @@ protocol bgp bgpdisco_{{ i++ }}_{{ replace(replace(neigh.iface, '.', '_'), '-', 
 	ipv6 {
 		table v6_bgpdisco;
 		import all;
-		export all;
+		export filter bgpdisco_export_v6;
 		gateway recursive;
-		next hop address 2001:db8::; # TODO: Safe some memory by using IPv4 NH
 	};
 }
 {% endfor %}


### PR DESCRIPTION
Typical route as readvertised from saarbruecker (working):
```
2001:bf7:760:10fc::1/128 unreachable [bgpdisco_1_eth4_12 2024-12-24 from fe80::f29f:c2ff:fe0f:793d] * (100) [i]
	Type: BGP univ
	BGP.origin: IGP
	BGP.as_path: 
	BGP.next_hop: 2001:db8:: fe80::f29f:c2ff:fe0f:793d
	BGP.local_pref: 100
	BGP.fa [t]: 5b 20 5b 20 30 2c 20 22 73 77 69 74 63 68 30 5f 31 30 34 2e 73 65 67 65 6e 2d 63 6f 72 65 22 20 5d 20 5d
```

Local route advertised from static protocol (non-working)
```
bird> show route 2001:bf7:760:2201::2/128 all export bgpdisco_9_gre4_ak36 
Table v6_bgpdisco:
2001:bf7:760:2201::2/128 blackhole [static_bgpdisco_v6 2024-12-18] * (200)
	Type: static univ
	BGP.fa [t]: 5b 20 5b 20 30 2c 20 22 67 72 65 34 2d 6c 31 30 35 2e 73 61 61 72 62 72 75 65 63 6b 65 72 2d 67 77 22 20 5d 20 5d
```

See commit msg for more details.