### PR TITLE
Luci-Mod-Falter (public status): iwdata can be nil

### DIFF
--- a/luci/luci-mod-falter/luasrc/view/freifunk/public_status.htm
+++ b/luci/luci-mod-falter/luasrc/view/freifunk/public_status.htm
@@ -264,7 +264,7 @@ end
 			netlist[#netlist+1] = net:ifname()
 			netdevs[net:ifname()] = dev:name()
 
-			if net.iwdata.device then
+			if net.iwinfo.signal and net.iwinfo.bssid then
 				local signal = net.iwinfo.signal or "N/A"
 				local noise = net.iwinfo.noise or "N/A"
 				local q = net.iwinfo.quality or "0"


### PR DESCRIPTION
Compile tested: yes (snapshot)
Run tested: yes

see here for reference https://github.com/openwrt/luci/pull/739

```
Runtime error
Unhandled exception during request dispatching
/usr/lib/lua/luci/ucodebridge.lua:23: /usr/lib/lua/luci/template.lua:181: Failed to execute template 'freifunk/public_status'.
A runtime error occurred: [string "/usr/lib/lua/luci/view/freifunk/public_stat..."]:116: attempt to index field 'iwdata' (a nil value)
```
![iwdata_nil](https://github.com/user-attachments/assets/fe158d36-a89c-49d8-a64a-ad8247ceeeb2)
