### PR TITLE
tunspace: static IP support, log spam prevention

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -124,4 +124,5 @@ EOF1
   | tee "$destdir/build.log" \
   >&2
 
+[ ! -f "$sdkdir/public-key.pem" ] || mv "$sdkdir/public-key.pem" "$destdir/"
 mv "$sdkdir/bin/packages/$arch"/falter/* "$destdir/falter/"

--- a/packages/tunspace/Makefile
+++ b/packages/tunspace/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tunspace
-PKG_RELEASE:=0
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Packet Please <pktpls@systemli.org>
 PKG_LICENSE:=GPL-2.0-only

--- a/packages/tunspace/tunspace.defaults
+++ b/packages/tunspace/tunspace.defaults
@@ -8,6 +8,8 @@ config tunspace "tunspace"
   option uplink_netns "uplink"
   option uplink_ifname "br-wan"
   option uplink_mode "bridge"
+  option uplink_ipv4 ""
+  option uplink_gateway ""
   option maintenance_interval 15
   option debug 0
 

--- a/packages/tunspace/tunspace.defaults
+++ b/packages/tunspace/tunspace.defaults
@@ -5,12 +5,21 @@ if [ ! -f /etc/config/tunspace ]; then
 package 'tunspace'
 
 config tunspace "tunspace"
+  # Namespace where the uplink will live.
   option uplink_netns "uplink"
+  # Existing interface that we'll use as the uplink.
   option uplink_ifname "br-wan"
+  # How the uplink in the namespace is constructed.
+  # - bridge: creates a macvlan child in bridge mode, useful for creating multiple uplinks from the same original uplink interface.
+  # - direct: moves the original uplink interface into the namespace directly, useful for wonky cheap USB sticks with broken drivers.
   option uplink_mode "bridge"
+  # Our own static uplink IPv4 address in CIDR format. Leave empty to use DHCP.
   option uplink_ipv4 ""
+  # IPv4 address of the gateway. Required in combination with uplink_ipv4, ignored when using DHCP.
   option uplink_gateway ""
+  # Maintenance consists of checking the uplink, refreshing the DHCP lease, checking the tunnel endpoints, and switching endpoints if neccessary.
   option maintenance_interval "15"
+  # Enables detailed output of Tunspace's operations. If disabled, only tunnel endpoint changes are reported.
   option debug "0"
 
 config wg-server

--- a/packages/tunspace/tunspace.defaults
+++ b/packages/tunspace/tunspace.defaults
@@ -10,46 +10,46 @@ config tunspace "tunspace"
   option uplink_mode "bridge"
   option uplink_ipv4 ""
   option uplink_gateway ""
-  option maintenance_interval 15
-  option debug 0
+  option maintenance_interval "15"
+  option debug "0"
 
 config wg-server
   option name "ak36"
   option url "https://77.87.51.11/ubus"
-  option insecure_cert 1
-  option disabled 0
+  option insecure_cert "1"
+  option disabled "0"
 
 config wg-server
   option name "l105"
   option url "https://77.87.49.8/ubus"
-  option insecure_cert 1
-  option disabled 0
+  option insecure_cert "1"
+  option disabled "0"
 
 config wg-server
   option name "ohlauer"
   option url "https://176.74.57.19/ubus"
-  option insecure_cert 1
-  option disabled 0
+  option insecure_cert "1"
+  option disabled "0"
 
 config wg-server
   option name "saarbruecker"
   option url "https://176.74.57.43/ubus"
-  option insecure_cert 1
-  option disabled 0
+  option insecure_cert "1"
+  option disabled "0"
 
 config wg-server
   option name "strom"
   option url "https://77.87.51.131/ubus"
-  option insecure_cert 1
-  option disabled 0
+  option insecure_cert "1"
+  option disabled "0"
 
 config wg-interface
   option ifname "ts_wg0"
   option ipv6 "fe80::2/64"
   option ipv4 "10.31.174.138/32"
-  option mtu 1280
-  option port 51820
-  option disabled 0
+  option mtu "1280"
+  option port "51820"
+  option disabled "0"
 
 EOT
 fi


### PR DESCRIPTION
Compile tested: x86_64, snapshot
Run tested: x86/64, snapshot, tunspace works with both static IP and DHCP, logspam is prevented

Description of your changes:
More info in the commit messages. Fixes #467 

The `build:` commit is unrelated and helps us build images with a custom package feed locally.