### PR TITLE
tunspace: remove problematic ifdown

### DIFF
--- a/packages/tunspace/tunspace.uc
+++ b/packages/tunspace/tunspace.uc
@@ -229,11 +229,6 @@ function wg_replace_endpoint(ifname, cfg, next) {
   let srvcfg = cfg.wireguard_servers[next];
   let certopt = srvcfg.insecure_cert ? "--no-check-certificate" : "";
 
-  // bring interface down to prevent OLSR and Babel from spamming syslog.
-  if (0 != shell_command("ip link set down "+ifname)) {
-    return false;
-  }
-
   // generate a fresh private key
   let randfd = fs.open("/dev/random");
   let privkey = randfd.read(32);


### PR DESCRIPTION
Kompiliert Ja/Nein: x86_64 snapshot
Läuft live Ja/Nein: tested on mediatek/mt7622 @ lacasahellersdorf

Beschreibung deiner Änderungen:

Not sure what I was thinking, this was never neccessary.

Apparantly on ifdown the link-local address fe80::2 gets removed, which permanently breaks the tunnel health check.

Don't bring the interface down anymore when changing endpoints.