### PR TITLE
falter-berlin-owm-ucode: use EXTRA_DEPENDS for faster builds

### DIFF
--- a/packages/falter-berlin-owm-ucode/Makefile
+++ b/packages/falter-berlin-owm-ucode/Makefile
@@ -23,7 +23,10 @@ endef
 define Package/falter-berlin-owm-ucode
 	$(call Package/falter-berlin-owm-ucode/default)
 	TITLE:=Freifunk Berlin owm.ucode
-  DEPENDS:=+ucode +ucode-mod-fs +ucode-mod-ubus +ucode-mod-uci +ucode-mod-resolv +ucode-mod-uloop +uclient-fetch
+  EXTRA_DEPENDS:= \
+    ucode (>=0), ucode-mod-fs (>=0), ucode-mod-ubus (>=0), \
+    ucode-mod-uci (>=0), ucode-mod-resolv (>=0), ucode-mod-uloop (>=0), \
+    uclient-fetch (>=0)
 endef
 
 define Package/falter-berlin-owm-ucode/description


### PR DESCRIPTION
Kompiliert Ja/Nein: x86_64 snapshot
Läuft live Ja/Nein: n/a

Beschreibung deiner Änderungen:

EXTRA_DEPENDS only adds to the dependencies in the package's APK metadata. It doesn't require the dependency to also be compiled. We get faster builds if we build fewer unneccessary packages.