### PR TITLE
bird2, bird3: update to 2.18.1 & 3.2.1

### DIFF
--- a/packages/bird2-babelpatch/Makefile
+++ b/packages/bird2-babelpatch/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird2-babelpatch
-PKG_VERSION:=2.18
+PKG_VERSION:=2.18.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://bird.nic.cz/download/
-PKG_HASH:=80e40ab7e73df9d521d5348cbb57b1399501af53f4d108fd8c24f6b14e3384c3
+PKG_HASH:=cb13248d6fe9c5f2b06d9d9e16983b4a6640ad94544499fc303f69688e89c50d
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/packages/bird3-babelpatch/Makefile
+++ b/packages/bird3-babelpatch/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird3-babelpatch
-PKG_VERSION:=3.2.0
+PKG_VERSION:=3.2.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://bird.nic.cz/download/
-PKG_HASH:=5e6ff6a22cf92ba73ebf2e4bbcd9360328b52c7497ef70e4cf11089fa5a216b2
+PKG_HASH:=fbdacb9150f33ffe465f220e9c54ecae582551bb63146fa7148d12335e1fbfad
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>, Nick Hainke <vincent@systemli.org>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Kompiliert Ja/Nein: x86_64 snapshot
Läuft live Ja/Nein: x86/64 snapshot VM

Beschreibung deiner Änderungen:
Version 3.2.1 (2026-04-01)
  o ASPA: Fix downstream validation
  o BMP: Fix route sending
  o BGP: Fix route refresh after restart
  o BGP: Fix dynamic peer connection
  o Filters: Fix string attributes
  o Filters: Fix ROA check autoreload reconfiguration
  o Logging: Fix error handling
  o Kernel: Fix graceful recovery
  o Pipe: Fix rare collision bug
  o Config: Allow keyword redefinition
Version 2.18.1 (2026-04-01)
  o ASPA: Fix downstream validation
  o Filters: Fix string attributes
  o Logging: Fix error handling