### PR TITLE
Revert "bbbdigger: convert postinst to uci-defaults"

### DIFF
--- a/packages/falter-berlin-bbbdigger/Makefile
+++ b/packages/falter-berlin-bbbdigger/Makefile
@@ -42,7 +42,13 @@ define Build/Compile
 endef
 
 define Package/falter-berlin-bbbdigger/install
-  $(CP) ./files/* $(1)/
+	$(INSTALL_DIR) $(1)/tmp
+	$(INSTALL_BIN) ./files/postinst.sh $(1)/tmp/falter-berlin-bbbdigger_postinst.sh
+endef
+
+define Package/falter-berlin-bbbdigger/postinst
+#!/bin/sh
+$${IPKG_INSTROOT}/tmp/falter-berlin-bbbdigger_postinst.sh
 endef
 
 $(eval $(call BuildPackage,falter-berlin-bbbdigger))

--- a/packages/falter-berlin-bbbdigger/files/postinst.sh
+++ b/packages/falter-berlin-bbbdigger/files/postinst.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# As part of firstboot, we don't want to smash an already set up config
+# As part of the install, we don't want to smash an already set up config
 # but at the same time update it if necessary.  The unique attributes are:
 #
 # network.bbbdigger_dev.macaddr
@@ -67,4 +67,8 @@ uci set olsrd.@Interface[-1].ignore=0
 uci set olsrd.@Interface[-1].interface=$IFACE
 uci set olsrd.@Interface[-1].Mode=ether
 
+#uci changes
+
 uci commit
+reload_config
+/etc/init.d/tunneldigger restart


### PR DESCRIPTION
This reverts commit 735ab407b0b820db443201877319569754ce28d2.

revert already done manually for the openwrt 24, 25 branches.