### PR TITLE
falter-defaults: add English as a supported lang

### DIFF
--- a/packages/falter-defaults/files/etc/uci-defaults/freifunk-berlin-luci-defaults
+++ b/packages/falter-defaults/files/etc/uci-defaults/freifunk-berlin-luci-defaults
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# shellcheck disable=SC1091
+
+. /lib/functions/guard.sh
+
+guard "luci"
+
+# add English to the list of supported languages
+uci set luci.languages.en='English'
+
+uci commit luci
+


### PR DESCRIPTION
Since english lang packets are no longer explicitly added to the images, we should add english as one of the valid options.  The laguage settings on the browser will choose the prefered language for the user.

Please cherry-pick into 24 and 25 branches.