### PR TITLE
luci: remove broken map snippet from the wizard

### DIFF
--- a/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua
+++ b/luci/luci-app-ffwizard-falter/luasrc/model/cbi/freifunk/assistent/generalInfo.lua
@@ -72,8 +72,9 @@ function alt.cfgvalue(self, section)
   return uci:get_first("system", "system","altitude")
 end
 
-map = f:field(DummyValue,"","")
-map.template = "freifunk/assistent/snippets/map"
+--remove broken map snippet
+--map = f:field(DummyValue,"","")
+--map.template = "freifunk/assistent/snippets/map"
 
 main = f:field(DummyValue, "config", "", "")
 main.forcewrite = true


### PR DESCRIPTION
This is already in the 24.x and 25.x branches.  