### PR TITLE
falter-berlin-bbbdigger: improve postinst script

### DIFF
--- a/packages/falter-berlin-bbbdigger/files/postinst.sh
+++ b/packages/falter-berlin-bbbdigger/files/postinst.sh
@@ -54,6 +54,7 @@ uci set network.${IFACE}_dev.name=$IFACE
 uci set network.$IFACE=interface
 uci set network.$IFACE.proto=dhcp
 uci set network.$IFACE.device=$IFACE
+uci set network.$IFACE.disabled=0
 
 # firewall setup (first remove from the zone and add it back)
 uci -q del_list firewall.zone_freifunk.network=$IFACE
@@ -71,4 +72,4 @@ uci set olsrd.@Interface[-1].Mode=ether
 
 uci commit
 reload_config
-/etc/init.d/tunneldigger restart
+/etc/init.d/tunneldigger restart bbbdigger


### PR DESCRIPTION
set the network interface option disabled to 0.  This is needed for the luci interface to know whether or not the interface is currently enabled or disabled.

restart only the bbbdigger interface when the script ends.  There is no need to do a total restart, causing ffuplink to restart.

fixes #565

This can be cherry-picked into openwrt 24 and 25.