### PR TITLE
migration: fix errors in the 1.3.1 migration

### DIFF
--- a/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/packages/falter-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -1112,11 +1112,9 @@ r1_3_1_domain_suffix() {
     log "setting the domain suffix to ${suffix}"
 
     # apply to dhcp config
-    uci del_list dhcp.dhcp.dhcp_option="119,olsr"
-    if [ $? -eq 0 ]; then
-      uci add_list dhcp.dhcp.dhcp_option="119,${suffix}"
-    fi
-    uci set dhcp.@dnsmasq[0].domain=".${suffix}"
+    uci delete dhcp.dhcp.dhcp_option
+    uci add_list dhcp.dhcp.dhcp_option="119,${suffix}"
+    uci set dhcp.@dnsmasq[0].domain="${suffix}"
 
     # apply to olsrd config
     olsrd_suffix() {
@@ -1125,7 +1123,7 @@ r1_3_1_domain_suffix() {
       local library=""
       config_get library "$section" library
       if [ "$library" = "olsrd_nameservice" ]; then
-        uci set "$config.$section".suffix=${suffix}
+        uci set "$config.$section".suffix=.${suffix}
       fi
     }
     reset_cb


### PR DESCRIPTION
These failurs are reran in the 1.4.1 migration, so the changes apply there too.

# Pull Request Vorlage / Template

Bitte die nicht-benutzte Sprachversion entfernen.
Please remove the Language version of this template, which you don't use.

------------ schnipp /snip ------------

Kompiliert Ja/Nein: (Bitte gib Prozessorarchitektur, Modell und Falter/OpenWrtversion an)
Läuft live Ja/Nein: (Bitte gib Prozessorarchitektur, Modell und Falter/OpenWrtversion an und wie du deine Änderungen getestet hast)

Beschreibung deiner Änderungen:

----------

Compile tested: (put here arch, model, Falter (_OpenWrt_) version)
Run tested: (put here arch, model, Falter (_OpenWrt_) version, tests done)

Description of your changes:
