### PR TITLE
workflow: disable runtime test for x86_64

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -22,7 +22,7 @@ jobs:
 
           - arch: x86_64
             target: x86-64
-            runtime_test: true
+            runtime_test: false
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
As this test is always failing, disable the test.  The whole workflow process needs to be reworked.

fixes #573

# Pull Request Vorlage / Template

Bitte die nicht-benutzte Sprachversion entfernen.
Please remove the Language version of this template, which you don't use.

------------ schnipp /snip ------------

Kompiliert Ja/Nein: (Bitte gib Prozessorarchitektur, Modell und Falter/OpenWrtversion an)
Läuft live Ja/Nein: (Bitte gib Prozessorarchitektur, Modell und Falter/OpenWrtversion an und wie du deine Änderungen getestet hast)

Beschreibung deiner Änderungen:

----------

Compile tested: (put here arch, model, Falter (_OpenWrt_) version)
Run tested: (put here arch, model, Falter (_OpenWrt_) version, tests done)

Description of your changes:
