### PR TITLE
owm: fix ipv6 formatting for push url and bad model name encoding

### DIFF
--- a/packages/falter-berlin-owm-ucode/Makefile
+++ b/packages/falter-berlin-owm-ucode/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=falter-berlin-owm-ucode
-PKG_VERSION:=1.0
+PKG_VERSION:=1.1
 
 PKG_MAINTAINER:=Tobias Schwarz <info@tobias-schwarz.com>
 PKG_LICENSE:=GPL-2.0-only

--- a/packages/falter-berlin-owm-ucode/owm.uc
+++ b/packages/falter-berlin-owm-ucode/owm.uc
@@ -225,10 +225,11 @@ function build_json_data() {
 		(board.release.distribution + ' ' + board.release.version);
 	let firmware_rev = ff_release.revision || board.release.revision;
 	
+	let model = match(board.model, /\w/) ? board.model : "generic";
 	let json_data = {
 		freifunk: { contact: {}, community: {} },
 		type: 'node', script: 'owm', api_rev: 1,
-		system: { sysinfo: ['system is deprecated', board.model], uptime: [info.uptime], loadavg: [info.load[1] * 1.0 / 65536] },
+		system: { sysinfo: ['system is deprecated', model], uptime: [info.uptime], loadavg: [info.load[1] * 1.0 / 65536] },
 		olsr: { ipv4Config: {} },
 		links: all_links,
 		latitude: latitude * 1, longitude: longitude * 1,

--- a/packages/falter-berlin-owm-ucode/owm.uc
+++ b/packages/falter-berlin-owm-ucode/owm.uc
@@ -130,8 +130,10 @@ function send_to_server(json_str, hostname) {
 	for (let type in [['AAAA'], ['A']]) {
 		let result = resolv.query(server, { type });
 		for (let d in result) {
-			let ips = type[0] === 'AAAA' ? (result[d]?.AAAA || []) : (result[d]?.A || []);
-			for (let ip in ips) if (try_ip(ip)) return true;
+			let url_formatted_ips = [];
+			for (let ipv6 in result[d]?.AAAA) push(url_formatted_ips, "[" + ipv6 + "]");
+			for (let ipv4 in result[d]?.A) push(url_formatted_ips, ipv4);
+			for (let ip in url_formatted_ips) if (try_ip(ip)) return true;
 		}
 	}
 	


### PR DESCRIPTION
This is a fix currently used at the newyorck installation. Maybe this makes sense to be included in the package?

Problem is that the system is returning a non utf8 encoded model name via DMI. Resulting in a bad encoding being embedded in the `board.json` and `ubus call system board`. This looks bad at some places (like the luci status page), but without making any trouble. But the owm upload is not working anymore. The server is not accepting the wrong encoded data. Resulting in the node not being visible on the map etc..

I think the problem should be solved in openwrt checking if the system returns valid data and replacing it with defaults. So that `board.json` and `ubus call system board` always return valid data. But for now this is a fix that we can implement right away.

For the encoding checking I wasn't sure how to do it. Now I just check if there is at least one valid character present in the string. Open for better suggestions. :)