### PR TITLE
bgpdisco: emit only one hostname per line

### DIFF
--- a/packages/bgpdisco/nameservice.uc
+++ b/packages/bgpdisco/nameservice.uc
@@ -115,9 +115,10 @@ function get_local_hosts() {
 // data = { ip: [hostname1, ..], }
 function write_hostnames(data) {
   let lines = [];
-  for (ip in data){
-    let hostnames = map(data[ip], function (v) {return v + '.' + cfg.domain;});
-    push(lines, ip + ' ' + join(' ', hostnames));
+  for (ip in data) {
+    for (hostname in data[ip]) {
+      push(lines, sprintf('%s %s.%s', ip, hostname, cfg.domain));
+    }
   }
   let contents = join('\n', lines) + '\n\n# Written by ffnameservice\n';
   let data_hash = digest.md5(contents);


### PR DESCRIPTION
Compile tested: x86_64 snapshot
Run tested: x86/64 generic

Description of your changes:
Dnsmasq doesn't seem to recognize multiple hostnames per line, so let's emit one hostname per line.