### PR TITLE
Draft: New monitor Package

### DIFF
--- a/packages/falter-berlin-monitor/Makefile
+++ b/packages/falter-berlin-monitor/Makefile
@@ -1,0 +1,36 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=falter-berlin-monitor
+PKG_RELEASE:=0
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/falter-berlin-monitor
+  SECTION:=falter-berlin
+  CATEGORY:=falter-berlin
+  TITLE:=Freifunk Monitor Statistics Collector
+  EXTRA_DEPENDS:=prometheus-node-exporter-ucode (>=0), prometheus-node-exporter-ucode-openwrt (>=0), prometheus-node-exporter-ucode-wifi (>=0)
+  PKGARCH:=all
+endef
+
+define Package/falter-berlin-monitor/description
+  Tool send, line go up!
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/falter-berlin-monitor/install
+	$(CP) ./files/freifunk.uc $(1)/usr/share/ucode/node-exporter/lib/
+endef
+
+$(eval $(call BuildPackage,falter-berlin-monitor))

--- a/packages/falter-berlin-monitor/README.md
+++ b/packages/falter-berlin-monitor/README.md
@@ -1,0 +1,17 @@
+# falter berlin monitor
+
+Replacement for owm.sh and collectd.
+
+This package adds a prometheus exporter with additions for our custom freifunk metrics.
+
+## Todo
+
+- Everything
+- Only add labels when they have a value
+- add Cronjob
+- fix Metrics
+- Think about how to design the metrics correctly
+- Lucy config page
+    - Enable sending metrics
+    - enable beeing shown on map (otherwise only send metrics)
+    - custom backend


### PR DESCRIPTION
First draft to Replace collectd and owm.sh with a prometheus pushgw implementation.

Nothing works right now, this is just a placeholder PR.


Goal:
- have a cronjob that runs every Minute and pushes the data from prometheus to our internal Pushgw
- Have custom scripts to enhance the default data with custom metrics (e.g. babel metrics, location etc)
- Have a config page to e.g. enable specific metrics like the location
- rely as much as possible on default openwrt packages